### PR TITLE
Int 615

### DIFF
--- a/src/main/java/gov/ca/cwds/data/persistence/cms/rep/ReplicatedClient.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/rep/ReplicatedClient.java
@@ -9,22 +9,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hibernate.annotations.NamedNativeQuery;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
 import gov.ca.cwds.dao.ApiClientCaseAware;
 import gov.ca.cwds.dao.ApiClientCountyAware;
 import gov.ca.cwds.dao.ApiClientRaceAndEthnicityAware;
@@ -112,6 +108,7 @@ public class ReplicatedClient extends BaseClient implements ApiPersonAware,
   private static final long serialVersionUID = 1L;
 
   private static final String HISPANIC_CODE_OTHER_ID = "02";
+  private static final Short CARIBBEAN_RACE_CODE = 3162;
 
   /**
    * A client can have multiple active addresses, typically one active address per address type.
@@ -215,7 +212,9 @@ public class ReplicatedClient extends BaseClient implements ApiPersonAware,
   }
 
   public void setSafetyAlerts(Map<String, ElasticSearchSafetyAlert> safetyAlerts) {
+    if (safetyAlerts != null) {
     this.safetyAlerts = safetyAlerts;
+    }
   }
 
   public void addSafetyAlert(ElasticSearchSafetyAlert safetyAlert) {
@@ -412,7 +411,7 @@ public class ReplicatedClient extends BaseClient implements ApiPersonAware,
       final SystemCode systemCode = SystemCodeCache.global().getSystemCode(codeId);
       if (systemCode != null) {
         description = systemCode.getShortDescription();
-        isHispanicCode = HISPANIC_CODE_OTHER_ID.equals(systemCode.getOtherCd());
+        isHispanicCode = (HISPANIC_CODE_OTHER_ID.equals(systemCode.getOtherCd()) && (!CARIBBEAN_RACE_CODE.equals(codeId)));        
       }
 
       final ElasticSearchSystemCode esCode = new ElasticSearchSystemCode();

--- a/src/test/java/gov/ca/cwds/data/persistence/cms/rep/ReplicatedClientTest.java
+++ b/src/test/java/gov/ca/cwds/data/persistence/cms/rep/ReplicatedClientTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
-
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -16,11 +15,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import gov.ca.cwds.data.es.ElasticSearchLegacyDescriptor;
 import gov.ca.cwds.data.es.ElasticSearchPersonAddress;
 import gov.ca.cwds.data.es.ElasticSearchPersonAka;
@@ -91,8 +88,15 @@ public class ReplicatedClientTest extends Goddard<ReplicatedClient, EsClientAddr
   public void setClientAddresses_Args__Set() throws Exception {
     final Set<ReplicatedClientAddress> clientAddresses = new HashSet<>();
     target.setClientAddresses(clientAddresses);
+    assertThat(target.getClientAddresses().isEmpty(), is(equalTo(Boolean.TRUE)));
   }
 
+  @Test 
+  public void shouldBeEmptyWhenClientAddressesIsNull() throws Exception {
+    target.setClientAddresses(null);
+    assertThat(target.getClientAddresses().isEmpty(), is(equalTo(Boolean.TRUE)));
+  }
+  
   @Test
   public void addClientAddress_Args__ReplicatedClientAddress() throws Exception {
     final ReplicatedClientAddress clientAddress = mock(ReplicatedClientAddress.class);
@@ -169,6 +173,13 @@ public class ReplicatedClientTest extends Goddard<ReplicatedClient, EsClientAddr
     final List<ElasticSearchSystemCode> expected = new ArrayList<>();
     assertThat(actual, is(equalTo(expected)));
   }
+  
+  @Test
+  public void shouldReturnClientCounties() throws Exception {
+    final short lakeCounty = 20;
+    target.addClientCounty(lakeCounty);
+    assertThat(target.getClientCounties().size(), is(equalTo(1)));
+  }
 
   @Test
   public void addClientCounty_Args__Short() throws Exception {
@@ -210,9 +221,37 @@ public class ReplicatedClientTest extends Goddard<ReplicatedClient, EsClientAddr
     target.setClientRaces(clientRaces);
 
     final ElasticSearchRaceAndEthnicity actual = target.getRaceAndEthnicity();
-    assertThat(actual, is(notNullValue()));
+    assertThat(actual.getRaceCodes().size(), is(equalTo(2)));
+    assertThat(actual.getHispanicCodes().size(), is(equalTo(1)));
   }
 
+  @Test
+  public void shouldNotBeHispanicWhenCaribbeanRace() throws Exception {
+    final List<Short> clientRaces = new ArrayList<>();
+    clientRaces.add((short) 3162);
+    target.setClientRaces(clientRaces);
+    final ElasticSearchRaceAndEthnicity actual = target.getRaceAndEthnicity();
+    assertThat(actual.getHispanicCodes().size(), is(equalTo(0)));
+  }
+  
+  @Test
+  public void shouldBeHispanicWhenNotCaribbeanRace() throws Exception {
+    final List<Short> clientRaces = new ArrayList<>();
+    clientRaces.add((short) 3164);
+    target.setClientRaces(clientRaces);
+    final ElasticSearchRaceAndEthnicity actual = target.getRaceAndEthnicity();
+    assertThat(actual.getHispanicCodes().size(), is(equalTo(1)));
+  }
+  
+  @Test
+  public void shouldNotBeHispanicWhenOtherCDIsNot02() throws Exception {
+    final List<Short> clientRaces = new ArrayList<>();
+    clientRaces.add((short) 842);
+    target.setClientRaces(clientRaces);
+    final ElasticSearchRaceAndEthnicity actual = target.getRaceAndEthnicity();
+    assertThat(actual.getHispanicCodes().size(), is(equalTo(0)));
+  }
+  
   @Test
   public void getAkas_Args__() throws Exception {
     final Map<String, ElasticSearchPersonAka> actual = target.getAkas();
@@ -231,6 +270,12 @@ public class ReplicatedClientTest extends Goddard<ReplicatedClient, EsClientAddr
     final ElasticSearchPersonAka aka = new ElasticSearchPersonAka();
     target.addAka(aka);
   }
+  
+  @Test
+  public void shouldBeEmptyWhenNullIsAddedToAka() throws Exception {
+    target.addAka(null);
+    assertThat(target.getAkas().isEmpty(), is(equalTo(Boolean.TRUE)));
+  }
 
   @Test
   public void getSafetyAlerts_Args__() throws Exception {
@@ -245,6 +290,13 @@ public class ReplicatedClientTest extends Goddard<ReplicatedClient, EsClientAddr
     target.setSafetyAlerts(safetyAlerts);
   }
 
+  @Test
+  public void shouldBeEmptyWhenNullIsSetToSafetyAlerts() throws Exception {
+    target.setSafetyAlerts(null);
+    assertThat(target.getSafetyAlerts().isEmpty(), is(equalTo(Boolean.TRUE)));
+    
+  }
+  
   @Test
   public void addSafetyAlert_Args__ElasticSearchSafetyAlert() throws Exception {
     final ElasticSearchSafetyAlert safetyAlert = mock(ElasticSearchSafetyAlert.class);
@@ -282,6 +334,12 @@ public class ReplicatedClientTest extends Goddard<ReplicatedClient, EsClientAddr
   public void addClientAddress_A$ReplicatedClientAddress() throws Exception {
     final ReplicatedClientAddress clientAddress = mock(ReplicatedClientAddress.class);
     target.addClientAddress(clientAddress);
+  }
+  
+  @Test
+  public void shouldBeEmptyWhenNullClientAddressIsAdded() throws Exception {
+    target.addClientAddress(null);
+    assertThat(target.getClientAddresses().isEmpty(), is(equalTo(Boolean.TRUE)));
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/data/persistence/cms/rep/ReplicatedClientTest.java
+++ b/src/test/java/gov/ca/cwds/data/persistence/cms/rep/ReplicatedClientTest.java
@@ -253,6 +253,16 @@ public class ReplicatedClientTest extends Goddard<ReplicatedClient, EsClientAddr
   }
   
   @Test
+  public void shouldSetHispanicOriginCodeToYes() throws Exception {
+    final List<Short> clientRaces = new ArrayList<>();
+    clientRaces.add((short) 3162);
+    target.setClientRaces(clientRaces);
+    target.setHispanicOriginCode("Y");
+    final ElasticSearchRaceAndEthnicity actual = target.getRaceAndEthnicity();
+    assertThat(actual.getHispanicOriginCode(), is(equalTo("Y")));
+  }
+  
+  @Test
   public void getAkas_Args__() throws Exception {
     final Map<String, ElasticSearchPersonAka> actual = target.getAkas();
     final Map<String, ElasticSearchPersonAka> expected = new HashMap<>();


### PR DESCRIPTION
modified:
**gov.ca.cwds.data.persistence.cms.rep.ReplicatedClient.java**
**addRaceAndEthnicity()**

when the associated other CD (SYS_CD_C->OTHER_CD) is "02" and the sys ID (SYS_CD_C->SYSTEM_ID) is **not** 3162 (Caribbean) load the sys ID value to the hispanic_codes[] array. Otherwise load the sys ID value to the race_codes[] array.

Note that the modification does not affect the "unable_to_determine_code", "hispanic_origin_code", or "hispanic_unable_to_determine_code" nodes. These values are determined by the value of the associated columns of the CLIENT row.