### PR TITLE
CALS-5936: No Facilities Found when Using Facility Type as a Filter Criteria

### DIFF
--- a/jobs-facilities-lis/src/test/java/gov/ca/cwds/jobs/cals/facility/LisFacilityJobTest.java
+++ b/jobs-facilities-lis/src/test/java/gov/ca/cwds/jobs/cals/facility/LisFacilityJobTest.java
@@ -51,7 +51,7 @@ public class LisFacilityJobTest {
       Thread.sleep(1000);
       addLisDataForIncrementalLoad();
       runIncrementalLoad();
-      Thread.sleep(1000);
+      Thread.sleep(5000);
       assertEquals(1, TestWriter.getItems().size());
       assertFacility("fixtures/facilities-lis.json",
           LIS_INITIAL_LOAD_FACILITY_ID);


### PR DESCRIPTION
fixed LIS tests;