### PR TITLE
Dave SNAP-340: correct last change end date

### DIFF
--- a/src/main/java/gov/ca/cwds/neutron/atom/AtomInitialLoad.java
+++ b/src/main/java/gov/ca/cwds/neutron/atom/AtomInitialLoad.java
@@ -264,7 +264,7 @@ public interface AtomInitialLoad<N extends PersistentObject, D extends ApiGroupN
       log.info("refresh MQT proc: status: {}, msg: {}", returnStatus, returnMsg);
 
       if (returnStatus.charAt(0) != '0') {
-        CheeseRay.runtime(log, "MQT REFRESH ERROR! {}", returnMsg);
+        throw CheeseRay.runtime(log, "MQT REFRESH ERROR! {}", returnMsg);
       }
     }
   }

--- a/src/main/java/gov/ca/cwds/neutron/enums/NeutronIntegerDefaults.java
+++ b/src/main/java/gov/ca/cwds/neutron/enums/NeutronIntegerDefaults.java
@@ -17,7 +17,7 @@ public enum NeutronIntegerDefaults {
    * To avoid missing changed records, look N minutes before the last successful run timestamp.
    * NOTE: make configurable.
    */
-  LOOKBACK_MINUTES(-13),
+  LOOKBACK_MINUTES(-11),
 
   /**
    * Default fetch size for Hibernate and JDBC. Pull records in bulk in order to minimize network

--- a/src/main/java/gov/ca/cwds/neutron/util/jdbc/NeutronDB2Utils.java
+++ b/src/main/java/gov/ca/cwds/neutron/util/jdbc/NeutronDB2Utils.java
@@ -40,7 +40,7 @@ public class NeutronDB2Utils {
   public static String prepLastChangeSQL(String sql, Date lastRunStartDate, Date lastRunEndDate) {
     final String strLastRunDate = NeutronDateUtils.makeSimpleDateString(lastRunStartDate);
     final String strStartDate = NeutronDateUtils.makeTimestampStringLookBack(lastRunStartDate);
-    final String strEndDate = NeutronDateUtils.makeTimestampStringLookBack(lastRunEndDate);
+    final String strEndDate = NeutronDateUtils.makeSimpleTimestampString(lastRunEndDate);
     return sql.replaceAll("XYZ", strStartDate).replaceAll("LAST_RUN_START", strStartDate)
         .replaceAll("LAST_RUN_END", strEndDate)
         .replaceAll("'CURRENT TIMESTAMP'", "CURRENT TIMESTAMP")

--- a/src/main/java/gov/ca/cwds/neutron/util/shrinkray/NeutronDateUtils.java
+++ b/src/main/java/gov/ca/cwds/neutron/util/shrinkray/NeutronDateUtils.java
@@ -56,8 +56,14 @@ public class NeutronDateUtils {
   }
 
   public static String makeSimpleTimestampString(final Date date) {
-    return new SimpleDateFormat(LEGACY_TIMESTAMP_FORMAT.getFormat())
-        .format(date != null ? date : new Date());
+    Date useThisDate = date;
+
+    if (date == null) {
+      final Calendar cal = Calendar.getInstance();
+      cal.add(Calendar.MINUTE, 2); // in case server time doesn't match database
+    }
+
+    return new SimpleDateFormat(LEGACY_TIMESTAMP_FORMAT.getFormat()).format(useThisDate);
   }
 
   public static String makeSimpleDateString(final Date date) {
@@ -72,7 +78,7 @@ public class NeutronDateUtils {
       ret = fmt.format(lookBack(date));
     } else {
       final Calendar cal = Calendar.getInstance();
-      cal.add(Calendar.MINUTE, -11);
+      cal.add(Calendar.MINUTE, NeutronIntegerDefaults.LOOKBACK_MINUTES.getValue());
       ret = fmt.format(lookBack(cal.getTime()));
     }
 

--- a/src/main/java/gov/ca/cwds/neutron/util/shrinkray/NeutronDateUtils.java
+++ b/src/main/java/gov/ca/cwds/neutron/util/shrinkray/NeutronDateUtils.java
@@ -56,7 +56,8 @@ public class NeutronDateUtils {
   }
 
   public static String makeSimpleTimestampString(final Date date) {
-    return new SimpleDateFormat(LEGACY_TIMESTAMP_FORMAT.getFormat()).format(date);
+    return new SimpleDateFormat(LEGACY_TIMESTAMP_FORMAT.getFormat())
+        .format(date != null ? date : new Date());
   }
 
   public static String makeSimpleDateString(final Date date) {

--- a/src/main/java/gov/ca/cwds/neutron/util/shrinkray/NeutronDateUtils.java
+++ b/src/main/java/gov/ca/cwds/neutron/util/shrinkray/NeutronDateUtils.java
@@ -72,7 +72,7 @@ public class NeutronDateUtils {
       ret = fmt.format(lookBack(date));
     } else {
       final Calendar cal = Calendar.getInstance();
-      cal.add(Calendar.MINUTE, 5);
+      cal.add(Calendar.MINUTE, -11);
       ret = fmt.format(lookBack(cal.getTime()));
     }
 

--- a/src/main/java/gov/ca/cwds/neutron/util/shrinkray/NeutronDateUtils.java
+++ b/src/main/java/gov/ca/cwds/neutron/util/shrinkray/NeutronDateUtils.java
@@ -61,6 +61,7 @@ public class NeutronDateUtils {
     if (date == null) {
       final Calendar cal = Calendar.getInstance();
       cal.add(Calendar.MINUTE, 2); // in case server time doesn't match database
+      useThisDate = cal.getTime();
     }
 
     return new SimpleDateFormat(LEGACY_TIMESTAMP_FORMAT.getFormat()).format(useThisDate);


### PR DESCRIPTION
Minor but important correction for last change end date.

Defaults to 2 minutes in the future to account for possible time differences between Rundeck servers and the mainframe DB2 database.