### PR TITLE
HOT-2450 Spike: Create Elasticsearch queries to include address in Se…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'jacoco'
 
 project.ext {
-    coreApiVersion = "1.7.5_856-RC"
+    coreApiVersion = "1.7.5_857-RC"
     log4jVersion = "2.8"
     elasticsearchVersion = "5.5.0"
     personIndexerJob = "gov.ca.cwds.jobs.PersonIndexerJob"

--- a/src/main/resources/neutron/elasticsearch/mapping/map_person_summary.json
+++ b/src/main/resources/neutron/elasticsearch/mapping/map_person_summary.json
@@ -177,6 +177,7 @@
 			"store": true
 		},
 		"addresses": {
+		    "type": "nested",
 			"properties": {
 				"id": {
 					"type": "text",
@@ -269,6 +270,12 @@
                     "store": true
                 },
                 "autocomplete_searchable_address": {
+                    "type": "text",
+                    "store": true,
+                     "analyzer": "autocomplete",
+                        "search_analyzer": "standard"
+                },
+                "autocomplete_city": {
                     "type": "text",
                     "store": true,
                      "analyzer": "autocomplete",


### PR DESCRIPTION
…arch

### JIRA Issue Link
- [HOT-2450 Spike: Create Elasticsearch queries to include address in Search](https://osi-cwds.atlassian.net/browse/HOT-2450)

### Technical Description
<!---Provide a technical description with context for those that don't know what this pull request is about.-->
Added a new field for Elasticsearch people-summary Index to facilitate Address search by autocomplete City and changed Addresses type to nested

### Tests
- [ ] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!---Please indicate why tests were not added.-->
unit test in api-core

### Types of changes
<!---What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
<!---Please list all new configuration parameters introduced by this pull request and describe meaning.-->
<!---Describe impact on automated deployment if any. Put N/A if not applicable.-->
N/A

### Technical debt
<!---If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->
N/A