### PR TITLE
HOT-2451 Create Elasticsearch queries to include address in Search, s…

### DIFF
--- a/src/main/resources/neutron/elasticsearch/queries/search/personsummary/address_city_only.json
+++ b/src/main/resources/neutron/elasticsearch/queries/search/personsummary/address_city_only.json
@@ -1,0 +1,124 @@
+{
+  "size": "10",
+  "track_scores": "true",
+  "sort": [
+    {
+      "_score": "desc",
+      "_uid": "desc"
+    }
+  ],
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match": {
+            "legacy_descriptor.legacy_table_name": "CLIENT_T"
+          }
+        },
+        {
+          "nested": {
+            "path": "addresses",
+            "query": {
+              "bool": {
+                "must": [
+                  {
+                    "match": {
+                      "addresses.autocomplete_city": {
+                        "query": "city_search_term"
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "addresses.last_known": {
+                        "query": "true"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "inner_hits": {
+              "highlight": {
+                "fields": {
+                  "addresses.autocomplete_city": {},
+                  "addresses.autocomplete_searchable_address": {},
+                  "addresses.county.description": {}
+                }
+              }
+            }
+          }
+        }
+      ],
+      "should": [
+        {
+          "nested": {
+            "path": "addresses",
+            "query": {
+              "bool": {
+                "should": 
+                  {
+                    "match": {
+                      "addresses.city": {
+                        "query": "city_search_term",
+                        "boost": "3"
+                      }
+                    }
+                  }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "_source": [
+    "id",
+    "legacy_source_table",
+    "first_name",
+    "middle_name",
+    "last_name",
+    "name_suffix",
+    "gender",
+    "date_of_birth",
+    "date_of_death",
+    "ssn",
+    "languages",
+    "races",
+    "ethnicity",
+    "client_counties",
+    "addresses.id",
+    "addresses.effective_start_date",
+    "addresses.street_name",
+    "addresses.street_number",
+    "addresses.city",
+    "addresses.state_code",
+    "addresses.zip",
+    "addresses.type",
+    "addresses.legacy_descriptor",
+    "addresses.phone_numbers.number",
+    "addresses.phone_numbers.type",
+    "phone_numbers.id",
+    "phone_numbers.number",
+    "phone_numbers.type",
+    "highlight",
+    "legacy_descriptor",
+    "sensitivity_indicator",
+    "race_ethnicity"
+  ],
+  "highlight": {
+    "order": "score",
+    "number_of_fragments": "10",
+    "require_field_match": "false",
+    "fields": {
+      "autocomplete_search_bar": {
+        "matched_fields": [
+          "autocomplete_search_bar",
+          "autocomplete_search_bar.phonetic",
+          "autocomplete_search_bar.diminutive"
+        ]
+      },
+      "searchable_date_of_birth": {}
+    }
+  }
+}

--- a/src/main/resources/neutron/elasticsearch/queries/search/personsummary/address_only.json
+++ b/src/main/resources/neutron/elasticsearch/queries/search/personsummary/address_only.json
@@ -1,0 +1,149 @@
+{
+  "size": "10",
+  "track_scores": "true",
+  "sort": [
+    {
+      "_score": "desc",
+      "_uid": "desc"
+    }
+  ],
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match": {
+            "legacy_descriptor.legacy_table_name": "CLIENT_T"
+          }
+        },
+        {
+          "nested": {
+            "path": "addresses",
+            "query": {
+              "bool": {
+                "must": [
+                  {
+                    "match": {
+                      "addresses.autocomplete_searchable_address": {
+                        "query": "street_number_and_name_search_term",
+                        "operator": "and"
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "addresses.autocomplete_city": {
+                        "query": "city_search_term"
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "addresses.county.description": {
+                        "query": "county_search_term"
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "addresses.last_known": {
+                        "query": "true"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "inner_hits": {
+              "highlight": {
+                "fields": {
+                  "addresses.autocomplete_city": {},
+                  "addresses.autocomplete_searchable_address": {},
+                  "addresses.county.description": {}
+                }
+              }
+            }
+          }
+        }
+      ],
+      "should": [
+        {
+          "nested": {
+            "path": "addresses",
+            "query": {
+              "bool": {
+                "should": [
+                  {
+                    "match": {
+                      "addresses.searchable_address": {
+                        "query": "street_number_and_name_search_term",
+                        "operator": "and",
+                        "boost": "3"
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "addresses.city": {
+                        "query": "city_search_term",
+                        "boost": "3"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "_source": [
+    "id",
+    "legacy_source_table",
+    "first_name",
+    "middle_name",
+    "last_name",
+    "name_suffix",
+    "gender",
+    "date_of_birth",
+    "date_of_death",
+    "ssn",
+    "languages",
+    "races",
+    "ethnicity",
+    "client_counties",
+    "addresses.id",
+    "addresses.effective_start_date",
+    "addresses.street_name",
+    "addresses.street_number",
+    "addresses.city",
+    "addresses.state_code",
+    "addresses.zip",
+    "addresses.type",
+    "addresses.legacy_descriptor",
+    "addresses.phone_numbers.number",
+    "addresses.phone_numbers.type",
+    "phone_numbers.id",
+    "phone_numbers.number",
+    "phone_numbers.type",
+    "highlight",
+    "legacy_descriptor",
+    "sensitivity_indicator",
+    "race_ethnicity"
+  ],
+  "highlight": {
+    "order": "score",
+    "number_of_fragments": "10",
+    "require_field_match": "false",
+    "fields": {
+      "autocomplete_search_bar": {
+        "matched_fields": [
+          "autocomplete_search_bar",
+          "autocomplete_search_bar.phonetic",
+          "autocomplete_search_bar.diminutive"
+        ]
+      },
+      "searchable_date_of_birth": {}
+    }
+  }
+}

--- a/src/main/resources/neutron/elasticsearch/queries/search/personsummary/person_and_address.json
+++ b/src/main/resources/neutron/elasticsearch/queries/search/personsummary/person_and_address.json
@@ -1,0 +1,240 @@
+{
+  "size": "10",
+  "track_scores": "true",
+  "sort": [
+    {
+      "_score": "desc",
+      "_uid": "desc"
+    }
+  ],
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "autocomplete_search_bar": {
+                    "query": "person_search_term",
+                    "fuzziness": "AUTO",
+                    "operator": "and",
+                    "boost": "2"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "autocomplete_search_bar.diminutive": {
+                    "query": "person_search_term",
+                    "operator": "and",
+                    "boost": "1"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "autocomplete_search_bar.phonetic": {
+                    "query": "person_search_term",
+                    "operator": "and",
+                    "boost": "1"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "match": {
+            "legacy_descriptor.legacy_table_name": "CLIENT_T"
+          }
+        },
+        {
+          "nested": {
+            "path": "addresses",
+            "query": {
+              "bool": {
+                "must": [
+                  {
+                    "match": {
+                      "addresses.autocomplete_searchable_address": {
+                        "query": "street_number_and_name_search_term",
+                        "operator": "and"
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "addresses.autocomplete_city": {
+                        "query": "city_search_term"
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "addresses.county.description": {
+                        "query": "county_search_term"
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "addresses.last_known": {
+                        "query": "true"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "inner_hits": {
+              "highlight": {
+                "fields": {
+                  "addresses.autocomplete_city": {},
+                  "addresses.autocomplete_searchable_address": {},
+                  "addresses.county.description": {}
+                }
+              }
+            }
+          }
+        }
+      ],
+      "should": [
+        {
+          "match": {
+            "autocomplete_search_bar": {
+              "query": "person_search_term",
+              "operator": "and",
+              "boost": "3"
+            }
+          }
+        },
+        {
+          "match": {
+            "first_name": {
+              "query": "person_search_term",
+              "boost": "7"
+            }
+          }
+        },
+        {
+          "match": {
+            "last_name": {
+              "query": "person_search_term",
+              "boost": "7"
+            }
+          }
+        },
+        {
+          "match": {
+            "first_name.phonetic": {
+              "query": "person_search_term",
+              "boost": "2"
+            }
+          }
+        },
+        {
+          "match": {
+            "last_name.phonetic": {
+              "query": "person_search_term",
+              "boost": "2"
+            }
+          }
+        },
+        {
+          "match": {
+            "date_of_birth_as_text": {
+              "query": "person_search_term",
+              "boost": "7"
+            }
+          }
+        },
+        {
+          "match": {
+            "ssn": {
+              "query": "person_search_term",
+              "boost": "7"
+            }
+          }
+        },
+        {
+          "nested": {
+            "path": "addresses",
+            "query": {
+              "bool": {
+                "should": [
+                  {
+                    "match": {
+                      "addresses.searchable_address": {
+                        "query": "street_number_and_name_search_term",
+                        "operator": "and",
+                        "boost": "3"
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "addresses.city": {
+                        "query": "city_search_term",
+                        "boost": "3"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "_source": [
+    "id",
+    "legacy_source_table",
+    "first_name",
+    "middle_name",
+    "last_name",
+    "name_suffix",
+    "gender",
+    "date_of_birth",
+    "date_of_death",
+    "ssn",
+    "languages",
+    "races",
+    "ethnicity",
+    "client_counties",
+    "addresses.id",
+    "addresses.effective_start_date",
+    "addresses.street_name",
+    "addresses.street_number",
+    "addresses.city",
+    "addresses.state_code",
+    "addresses.zip",
+    "addresses.type",
+    "addresses.legacy_descriptor",
+    "addresses.phone_numbers.number",
+    "addresses.phone_numbers.type",
+    "phone_numbers.id",
+    "phone_numbers.number",
+    "phone_numbers.type",
+    "highlight",
+    "legacy_descriptor",
+    "sensitivity_indicator",
+    "race_ethnicity"
+  ],
+  "highlight": {
+    "order": "score",
+    "number_of_fragments": "10",
+    "require_field_match": "false",
+    "fields": {
+      "autocomplete_search_bar": {
+        "matched_fields": [
+          "autocomplete_search_bar",
+          "autocomplete_search_bar.phonetic",
+          "autocomplete_search_bar.diminutive"
+        ]
+      },
+      "searchable_date_of_birth": {}
+    }
+  }
+}

--- a/src/main/resources/neutron/elasticsearch/queries/search/personsummary/person_and_address_with_no_address_highlighting.json
+++ b/src/main/resources/neutron/elasticsearch/queries/search/personsummary/person_and_address_with_no_address_highlighting.json
@@ -1,0 +1,231 @@
+{
+  "size": "10",
+  "track_scores": "true",
+  "sort": [
+    {
+      "_score": "desc",
+      "_uid": "desc"
+    }
+  ],
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "autocomplete_search_bar": {
+                    "query": "person_search_term",
+                    "fuzziness": "AUTO",
+                    "operator": "and",
+                    "boost": "2"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "autocomplete_search_bar.diminutive": {
+                    "query": "person_search_term",
+                    "operator": "and",
+                    "boost": "1"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "autocomplete_search_bar.phonetic": {
+                    "query": "person_search_term",
+                    "operator": "and",
+                    "boost": "1"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "match": {
+            "legacy_descriptor.legacy_table_name": "CLIENT_T"
+          }
+        },
+        {
+          "nested": {
+            "path": "addresses",
+            "query": {
+              "bool": {
+                "must": [
+                  {
+                    "match": {
+                      "addresses.autocomplete_searchable_address": {
+                        "query": "street_number_and_name_search_term",
+                        "operator": "and"
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "addresses.autocomplete_city": {
+                        "query": "city_search_term"
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "addresses.county.description": {
+                        "query": "county_search_term"
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "addresses.last_known": {
+                        "query": "true"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "should": [
+        {
+          "match": {
+            "autocomplete_search_bar": {
+              "query": "person_search_term",
+              "operator": "and",
+              "boost": "3"
+            }
+          }
+        },
+        {
+          "match": {
+            "first_name": {
+              "query": "person_search_term",
+              "boost": "7"
+            }
+          }
+        },
+        {
+          "match": {
+            "last_name": {
+              "query": "person_search_term",
+              "boost": "7"
+            }
+          }
+        },
+        {
+          "match": {
+            "first_name.phonetic": {
+              "query": "person_search_term",
+              "boost": "2"
+            }
+          }
+        },
+        {
+          "match": {
+            "last_name.phonetic": {
+              "query": "person_search_term",
+              "boost": "2"
+            }
+          }
+        },
+        {
+          "match": {
+            "date_of_birth_as_text": {
+              "query": "person_search_term",
+              "boost": "7"
+            }
+          }
+        },
+        {
+          "match": {
+            "ssn": {
+              "query": "person_search_term",
+              "boost": "7"
+            }
+          }
+        },
+        {
+          "nested": {
+            "path": "addresses",
+            "query": {
+              "bool": {
+                "should": [
+                  {
+                    "match": {
+                      "addresses.searchable_address": {
+                        "query": "street_number_and_name_search_term",
+                        "operator": "and",
+                        "boost": "3"
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "addresses.city": {
+                        "query": "city_search_term",
+                        "boost": "3"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "_source": [
+    "id",
+    "legacy_source_table",
+    "first_name",
+    "middle_name",
+    "last_name",
+    "name_suffix",
+    "gender",
+    "date_of_birth",
+    "date_of_death",
+    "ssn",
+    "languages",
+    "races",
+    "ethnicity",
+    "client_counties",
+    "addresses.id",
+    "addresses.effective_start_date",
+    "addresses.street_name",
+    "addresses.street_number",
+    "addresses.city",
+    "addresses.state_code",
+    "addresses.zip",
+    "addresses.type",
+    "addresses.legacy_descriptor",
+    "addresses.phone_numbers.number",
+    "addresses.phone_numbers.type",
+    "phone_numbers.id",
+    "phone_numbers.number",
+    "phone_numbers.type",
+    "highlight",
+    "legacy_descriptor",
+    "sensitivity_indicator",
+    "race_ethnicity"
+  ],
+  "highlight": {
+    "order": "score",
+    "number_of_fragments": "10",
+    "require_field_match": "false",
+    "fields": {
+      "autocomplete_search_bar": {
+        "matched_fields": [
+          "autocomplete_search_bar",
+          "autocomplete_search_bar.phonetic",
+          "autocomplete_search_bar.diminutive"
+        ]
+      },
+      "searchable_date_of_birth": {}
+    }
+  }
+}

--- a/src/main/resources/neutron/elasticsearch/queries/search/personsummary/person_only.json
+++ b/src/main/resources/neutron/elasticsearch/queries/search/personsummary/person_only.json
@@ -1,0 +1,163 @@
+{
+  "size": "10",
+  "track_scores": "true",
+  "sort": [
+    {
+      "_score": "desc",
+      "_uid": "desc"
+    }
+  ],
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "autocomplete_search_bar": {
+                    "query": "person_search_term",
+                    "fuzziness": "AUTO",
+                    "operator": "and",
+                    "boost": "2"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "autocomplete_search_bar.diminutive": {
+                    "query": "person_search_term",
+                    "operator": "and",
+                    "boost": "1"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "autocomplete_search_bar.phonetic": {
+                    "query": "person_search_term",
+                    "operator": "and",
+                    "boost": "1"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "match": {
+            "legacy_descriptor.legacy_table_name": "CLIENT_T"
+          }
+        }
+      ],
+      "should": [
+        {
+          "match": {
+            "autocomplete_search_bar": {
+              "query": "person_search_term",
+              "operator": "and",
+              "boost": "3"
+            }
+          }
+        },
+        {
+          "match": {
+            "first_name": {
+              "query": "person_search_term",
+              "boost": "7"
+            }
+          }
+        },
+        {
+          "match": {
+            "last_name": {
+              "query": "person_search_term",
+              "boost": "7"
+            }
+          }
+        },
+        {
+          "match": {
+            "first_name.phonetic": {
+              "query": "person_search_term",
+              "boost": "2"
+            }
+          }
+        },
+        {
+          "match": {
+            "last_name.phonetic": {
+              "query": "person_search_term",
+              "boost": "2"
+            }
+          }
+        },
+        {
+          "match": {
+            "date_of_birth_as_text": {
+              "query": "person_search_term",
+              "boost": "7"
+            }
+          }
+        },
+        {
+          "match": {
+            "ssn": {
+              "query": "person_search_term",
+              "boost": "7"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "_source": [
+    "id",
+    "legacy_source_table",
+    "first_name",
+    "middle_name",
+    "last_name",
+    "name_suffix",
+    "gender",
+    "date_of_birth",
+    "date_of_death",
+    "ssn",
+    "languages",
+    "races",
+    "ethnicity",
+    "client_counties",
+    "addresses.id",
+    "addresses.effective_start_date",
+    "addresses.street_name",
+    "addresses.street_number",
+    "addresses.city",
+    "addresses.state_code",
+    "addresses.zip",
+    "addresses.type",
+    "addresses.legacy_descriptor",
+    "addresses.phone_numbers.number",
+    "addresses.phone_numbers.type",
+    "phone_numbers.id",
+    "phone_numbers.number",
+    "phone_numbers.type",
+    "highlight",
+    "legacy_descriptor",
+    "sensitivity_indicator",
+    "race_ethnicity"
+  ],
+  "highlight": {
+    "order": "score",
+    "number_of_fragments": "10",
+    "require_field_match": "false",
+    "fields": {
+      "autocomplete_search_bar": {
+        "matched_fields": [
+          "autocomplete_search_bar",
+          "autocomplete_search_bar.phonetic",
+          "autocomplete_search_bar.diminutive"
+        ]
+      },
+      "searchable_date_of_birth": {}
+    }
+  }
+}


### PR DESCRIPTION
…ample queries that may be used by intake as a starting point to include address in people-summary search

### JIRA Issue Link
- [HOT-2451 Create Elasticsearch queries to include address in Search](https://osi-cwds.atlassian.net/browse/HOT-2451)

### Technical Description
<!---Provide a technical description with context for those that don't know what this pull request is about.-->
Sample queries that may be used as a starting point to include address in people-summary search

### Tests
- [ ] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!---Please indicate why tests were not added.-->
these are only sample queries, no unit tests required

### Types of changes
<!---What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
documentation only, no behavior change
### Configuration changes
<!---Please list all new configuration parameters introduced by this pull request and describe meaning.-->
<!---Describe impact on automated deployment if any. Put N/A if not applicable.-->
N/A

### Technical debt
<!---If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->
N/A