### PR TITLE
Dave SNAP-715

### DIFF
--- a/src/main/java/gov/ca/cwds/jobs/ClientIndexerJob.java
+++ b/src/main/java/gov/ca/cwds/jobs/ClientIndexerJob.java
@@ -1,6 +1,8 @@
 package gov.ca.cwds.jobs;
 
 import gov.ca.cwds.neutron.atom.AtomLaunchDirector;
+
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -177,7 +179,7 @@ public class ClientIndexerJob extends InitialLoadJdbcRocket<ReplicatedClient, Es
    * {@inheritDoc}
    */
   @Override
-  public void handleMainResults(final ResultSet rs) throws SQLException {
+  public void handleMainResults(final ResultSet rs, Connection con) throws SQLException {
     int cntr = 0;
     EsClientAddress m;
     Object lastId = new Object();

--- a/src/main/java/gov/ca/cwds/jobs/ClientPersonIndexerJob.java
+++ b/src/main/java/gov/ca/cwds/jobs/ClientPersonIndexerJob.java
@@ -152,7 +152,7 @@ public class ClientPersonIndexerJob extends InitialLoadJdbcRocket<ReplicatedClie
 
     buf.append(getJdbcOrderBy()).append(" FOR READ ONLY WITH UR ");
     ret = buf.toString();
-    LOGGER.info("initial load: SQL: {}", ret);
+    LOGGER.info("initial load: SQL:\n{}\n", ret);
 
     return ret;
   }
@@ -171,7 +171,7 @@ public class ClientPersonIndexerJob extends InitialLoadJdbcRocket<ReplicatedClie
       throw CheeseRay.runtime(LOGGER, e, "ERROR BUILDING LAST CHANGE SQL! {}", e.getMessage());
     }
 
-    LOGGER.info("last change: SQL: {}", ret);
+    LOGGER.info("last change: SQL:\n{}\n", ret);
     return ret;
   }
 
@@ -192,7 +192,7 @@ public class ClientPersonIndexerJob extends InitialLoadJdbcRocket<ReplicatedClie
 
   @Override
   public List<Pair<String, String>> getPartitionRanges() throws NeutronCheckedException {
-    return NeutronJdbcUtils.getCommonPartitionRanges512(this);
+    return NeutronJdbcUtils.getCommonPartitionRanges1024(this);
   }
 
   /**

--- a/src/main/java/gov/ca/cwds/jobs/ClientPersonIndexerJob.java
+++ b/src/main/java/gov/ca/cwds/jobs/ClientPersonIndexerJob.java
@@ -152,7 +152,7 @@ public class ClientPersonIndexerJob extends InitialLoadJdbcRocket<ReplicatedClie
 
     buf.append(getJdbcOrderBy()).append(" FOR READ ONLY WITH UR ");
     ret = buf.toString();
-    LOGGER.info("initial load: SQL:\n{}\n", ret);
+    LOGGER.info("initial load: SQL:\n\n{}\n", ret);
 
     return ret;
   }
@@ -171,7 +171,7 @@ public class ClientPersonIndexerJob extends InitialLoadJdbcRocket<ReplicatedClie
       throw CheeseRay.runtime(LOGGER, e, "ERROR BUILDING LAST CHANGE SQL! {}", e.getMessage());
     }
 
-    LOGGER.info("last change: SQL:\n{}\n", ret);
+    LOGGER.info("last change: SQL:\n\n{}\n", ret);
     return ret;
   }
 

--- a/src/main/java/gov/ca/cwds/jobs/ClientPersonIndexerJob.java
+++ b/src/main/java/gov/ca/cwds/jobs/ClientPersonIndexerJob.java
@@ -141,6 +141,7 @@ public class ClientPersonIndexerJob extends InitialLoadJdbcRocket<ReplicatedClie
 
   @Override
   public String getInitialLoadQuery(String dbSchemaName) {
+    String ret = null;
     final StringBuilder buf = new StringBuilder();
     buf.append("SELECT x.* FROM ").append(dbSchemaName).append('.').append(getInitialLoadViewName())
         .append(" x WHERE X.CLT_IDENTIFIER BETWEEN ':fromId' AND ':toId' ");
@@ -150,7 +151,10 @@ public class ClientPersonIndexerJob extends InitialLoadJdbcRocket<ReplicatedClie
     }
 
     buf.append(getJdbcOrderBy()).append(" FOR READ ONLY WITH UR ");
-    return buf.toString();
+    ret = buf.toString();
+    LOGGER.info("initial load: SQL: {}", ret);
+
+    return ret;
   }
 
   /**
@@ -159,12 +163,16 @@ public class ClientPersonIndexerJob extends InitialLoadJdbcRocket<ReplicatedClie
    */
   @Override
   public String getPrepLastChangeSQL() {
+    String ret = null;
     try {
-      return NeutronDB2Utils.prepLastChangeSQL(ClientSQLResource.INSERT_CLIENT_LAST_CHG,
+      ret = NeutronDB2Utils.prepLastChangeSQL(ClientSQLResource.INSERT_CLIENT_LAST_CHG,
           determineLastSuccessfulRunTime(), getFlightPlan().getOverrideLastEndTime());
     } catch (Exception e) {
       throw CheeseRay.runtime(LOGGER, e, "ERROR BUILDING LAST CHANGE SQL! {}", e.getMessage());
     }
+
+    LOGGER.info("last change: SQL: {}", ret);
+    return ret;
   }
 
   @Override

--- a/src/main/java/gov/ca/cwds/jobs/ClientPersonIndexerJob.java
+++ b/src/main/java/gov/ca/cwds/jobs/ClientPersonIndexerJob.java
@@ -254,8 +254,8 @@ public class ClientPersonIndexerJob extends InitialLoadJdbcRocket<ReplicatedClie
    * {@inheritDoc}
    */
   @Override
-  public void handleMainResults(final ResultSet rs) throws SQLException {
-    handler.get().handleMainResults(rs);
+  public void handleMainResults(final ResultSet rs, Connection con) throws SQLException {
+    handler.get().handleMainResults(rs, null);
   }
 
   @Override

--- a/src/main/java/gov/ca/cwds/jobs/ClientPersonIndexerJob.java
+++ b/src/main/java/gov/ca/cwds/jobs/ClientPersonIndexerJob.java
@@ -255,7 +255,7 @@ public class ClientPersonIndexerJob extends InitialLoadJdbcRocket<ReplicatedClie
    */
   @Override
   public void handleMainResults(final ResultSet rs, Connection con) throws SQLException {
-    handler.get().handleMainResults(rs, null);
+    handler.get().handleMainResults(rs, con);
   }
 
   @Override

--- a/src/main/java/gov/ca/cwds/jobs/ReferralHistoryIndexerJob.java
+++ b/src/main/java/gov/ca/cwds/jobs/ReferralHistoryIndexerJob.java
@@ -1,6 +1,5 @@
 package gov.ca.cwds.jobs;
 
-import gov.ca.cwds.neutron.atom.AtomLaunchDirector;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -34,6 +33,7 @@ import gov.ca.cwds.data.persistence.cms.ReplicatedPersonReferrals;
 import gov.ca.cwds.data.persistence.cms.rep.CmsReplicationOperation;
 import gov.ca.cwds.data.std.ApiGroupNormalizer;
 import gov.ca.cwds.jobs.schedule.LaunchCommand;
+import gov.ca.cwds.neutron.atom.AtomLaunchDirector;
 import gov.ca.cwds.neutron.atom.AtomRowMapper;
 import gov.ca.cwds.neutron.enums.NeutronIntegerDefaults;
 import gov.ca.cwds.neutron.exception.NeutronCheckedException;
@@ -221,8 +221,7 @@ public class ReferralHistoryIndexerJob
   @Inject
   public ReferralHistoryIndexerJob(ReplicatedPersonReferralsDao dao,
       @Named("elasticsearch.dao.people") ElasticsearchDao esDao, @LastRunFile String lastRunFile,
-      ObjectMapper mapper, FlightPlan flightPlan,
-      AtomLaunchDirector launchDirector) {
+      ObjectMapper mapper, FlightPlan flightPlan, AtomLaunchDirector launchDirector) {
     super(dao, esDao, lastRunFile, mapper, flightPlan, launchDirector);
   }
 
@@ -267,7 +266,7 @@ public class ReferralHistoryIndexerJob
    * @throws SQLException on database error
    */
   protected synchronized Connection getConnection() throws SQLException {
-    return NeutronJdbcUtils.prepConnection(jobDao.getSessionFactory());
+    return NeutronJdbcUtils.prepConnection(jobDao.grabSession());
   }
 
   /**
@@ -426,9 +425,11 @@ public class ReferralHistoryIndexerJob
   /**
    * Release heap objects early and often. Good time to <strong>request</strong> garbage collection,
    * not demand it. Java GC runs in a dedicated thread anyway.
+   * 
    * <p>
    * SonarQube disagrees.
    * </p>
+   * 
    * The catch: when many threads run, parallel GC may not get sufficient CPU cycles, until heap
    * memory is exhausted. Yes, this is a good place to drop a hint to GC that it
    * <strong>might</strong> want to clean up memory.

--- a/src/main/java/gov/ca/cwds/jobs/RelationshipIndexerJob.java
+++ b/src/main/java/gov/ca/cwds/jobs/RelationshipIndexerJob.java
@@ -2,6 +2,7 @@ package gov.ca.cwds.jobs;
 
 import gov.ca.cwds.neutron.atom.AtomLaunchDirector;
 import java.io.IOException;
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -181,7 +182,7 @@ public class RelationshipIndexerJob
    * @throws SQLException on database error
    */
   @Override
-  public void handleMainResults(final ResultSet rs) throws SQLException {
+  public void handleMainResults(final ResultSet rs, Connection con) throws SQLException {
     int cntr = 0;
     EsRelationship m;
     Object lastId = new Object();

--- a/src/main/java/gov/ca/cwds/jobs/schedule/LaunchCommand.java
+++ b/src/main/java/gov/ca/cwds/jobs/schedule/LaunchCommand.java
@@ -28,6 +28,7 @@ import com.google.inject.Injector;
 
 import gov.ca.cwds.neutron.atom.AtomCommandCenterConsole;
 import gov.ca.cwds.neutron.atom.AtomFlightRecorder;
+import gov.ca.cwds.neutron.atom.AtomHibernate;
 import gov.ca.cwds.neutron.atom.AtomLaunchCommand;
 import gov.ca.cwds.neutron.atom.AtomLaunchDirector;
 import gov.ca.cwds.neutron.enums.NeutronDateTimeFormat;
@@ -51,9 +52,9 @@ public class LaunchCommand implements AutoCloseable, AtomLaunchCommand {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(LaunchCommand.class);
 
-  protected static final List<String> DB_PROPERTY_LIST =
-      Collections.unmodifiableList(asList("DB_NS_USER", "DB_NS_PASSWORD", "DB_NS_JDBC_URL",
-          "DB_CMS_USER", "DB_CMS_PASSWORD", "DB_CMS_JDBC_URL", "DB_CMS_SCHEMA", "LAUNCH_DIR"));
+  protected static final List<String> DB_PROPERTY_LIST = Collections
+      .unmodifiableList(asList("DB_NS_USER", "DB_NS_PASSWORD", "DB_NS_JDBC_URL", "DB_CMS_USER",
+          "DB_CMS_PASSWORD", "DB_CMS_JDBC_URL", AtomHibernate.CURRENT_SCHEMA, "LAUNCH_DIR"));
 
   /**
    * Singleton instance. One launch director to rule them all!

--- a/src/main/java/gov/ca/cwds/neutron/atom/AtomHibernate.java
+++ b/src/main/java/gov/ca/cwds/neutron/atom/AtomHibernate.java
@@ -151,7 +151,8 @@ public interface AtomHibernate<T extends PersistentObject, M extends ApiGroupNor
    * Detect large data sets on the mainframe.
    * 
    * <p>
-   * <strong>HACK:</strong> also checks schema name. Add a "database version" table or something.
+   * <strong>HACK:</strong> also checks schema name. Add a "database version" table or get client
+   * count.
    * </p>
    * 
    * @return true if is large data set on z/OS
@@ -160,8 +161,8 @@ public interface AtomHibernate<T extends PersistentObject, M extends ApiGroupNor
   default boolean isLargeDataSet() throws NeutronCheckedException {
     final String schema = getDBSchemaName().toUpperCase().trim();
 
-    // TODO: Not the best idea to check by replication schema name.
-    // Get the client count instead.
+    // TODO: Bad idea to check data size by replication schema name.
+    // Get the client count instead. Need a client DAO.
     return isDB2OnZOS()
         && (schema.endsWith("RSQ") || schema.endsWith("REP") || schema.endsWith("RSS"));
   }

--- a/src/main/java/gov/ca/cwds/neutron/atom/AtomHibernate.java
+++ b/src/main/java/gov/ca/cwds/neutron/atom/AtomHibernate.java
@@ -31,6 +31,8 @@ import gov.ca.cwds.neutron.util.jdbc.NeutronJdbcUtils;
 public interface AtomHibernate<T extends PersistentObject, M extends ApiGroupNormalizer<?>>
     extends AtomShared, AtomRowMapper<M> {
 
+  public static final String CURRENT_SCHEMA = "DB_CMS_SCHEMA";
+
   /**
    * @return the rocket's main DAO.
    */
@@ -40,14 +42,14 @@ public interface AtomHibernate<T extends PersistentObject, M extends ApiGroupNor
    * @return default CMS schema name
    */
   default String getDBSchemaName() {
-    return System.getProperty("DB_CMS_SCHEMA");
+    return System.getProperty(CURRENT_SCHEMA);
   }
 
   /**
    * @return default CMS schema name
    */
   static String databaseSchemaName() {
-    return System.getProperty("DB_CMS_SCHEMA");
+    return System.getProperty(CURRENT_SCHEMA);
   }
 
   /**
@@ -158,7 +160,8 @@ public interface AtomHibernate<T extends PersistentObject, M extends ApiGroupNor
   default boolean isLargeDataSet() throws NeutronCheckedException {
     final String schema = getDBSchemaName().toUpperCase().trim();
 
-    // Not the best idea to check by replication schema name, but we lack other options.
+    // TODO: Not the best idea to check by replication schema name.
+    // Get the client count instead.
     return isDB2OnZOS()
         && (schema.endsWith("RSQ") || schema.endsWith("REP") || schema.endsWith("RSS"));
   }

--- a/src/main/java/gov/ca/cwds/neutron/atom/AtomInitialLoad.java
+++ b/src/main/java/gov/ca/cwds/neutron/atom/AtomInitialLoad.java
@@ -156,9 +156,10 @@ public interface AtomInitialLoad<N extends PersistentObject, D extends ApiGroupN
           stmt.setFetchSize(FETCH_SIZE.getValue());
 
           try (final ResultSet rs = stmt.executeQuery(query)) {
-            handleMainResults(rs);
+            handleMainResults(rs, con);
           } catch (Exception ex) {
-            log.debug("ERROR CLOSING RESULT SET!", ex); // don't re-throw, for now
+            // Don't re-throw, for now
+            log.debug("AtomicInitialLoad.pullRange(): ERROR CLOSING RESULT SET!", ex);
           } finally {
             // Close result set.
           }
@@ -174,7 +175,7 @@ public interface AtomInitialLoad<N extends PersistentObject, D extends ApiGroupN
         try {
           con.rollback();
         } catch (Exception e2) {
-          log.trace("NESTED EXCEPTION", e2);
+          log.trace("AtomicInitialLoad.pullRange(): NESTED ROLLBACK EXCEPTION!", e2);
         }
         throw e;
       } finally {

--- a/src/main/java/gov/ca/cwds/neutron/atom/AtomInitialLoad.java
+++ b/src/main/java/gov/ca/cwds/neutron/atom/AtomInitialLoad.java
@@ -157,6 +157,8 @@ public interface AtomInitialLoad<N extends PersistentObject, D extends ApiGroupN
 
           try (final ResultSet rs = stmt.executeQuery(query)) {
             handleMainResults(rs);
+          } catch (Exception ex) {
+            log.debug("ERROR CLOSING RESULT SET!", ex); // don't re-throw, for now
           } finally {
             // Close result set.
           }
@@ -165,6 +167,7 @@ public interface AtomInitialLoad<N extends PersistentObject, D extends ApiGroupN
         }
 
         // Handle additional JDBC statements, if any.
+        con.commit(); // Clear temp tables
         handleSecondaryJdbc(con, range);
         con.commit(); // Clear temp tables
       } catch (Exception e) {

--- a/src/main/java/gov/ca/cwds/neutron/atom/AtomLoadStepHandler.java
+++ b/src/main/java/gov/ca/cwds/neutron/atom/AtomLoadStepHandler.java
@@ -26,9 +26,10 @@ public interface AtomLoadStepHandler<N extends PersistentObject> {
    * no-op.
    * 
    * @param rs result set for this key range
+   * @param con raw JDBC connection
    * @throws SQLException on database error
    */
-  default void handleMainResults(final ResultSet rs) throws SQLException {
+  default void handleMainResults(final ResultSet rs, Connection con) throws SQLException {
     // Provide your own solution, for now.
   }
 

--- a/src/main/java/gov/ca/cwds/neutron/enums/NeutronIntegerDefaults.java
+++ b/src/main/java/gov/ca/cwds/neutron/enums/NeutronIntegerDefaults.java
@@ -9,6 +9,9 @@ import gov.ca.cwds.neutron.jetpack.JobLogs;
  */
 public enum NeutronIntegerDefaults {
 
+  /**
+   * Give Elasticsearch bulk indexing a chance to catch its breath.
+   */
   WAIT_BULK_PROCESSOR(25),
 
   /**

--- a/src/main/java/gov/ca/cwds/neutron/enums/NeutronIntegerDefaults.java
+++ b/src/main/java/gov/ca/cwds/neutron/enums/NeutronIntegerDefaults.java
@@ -40,9 +40,9 @@ public enum NeutronIntegerDefaults {
   FETCH_SIZE(5000),
 
   /**
-   * Let queries run -- until it's time to give up.
+   * Let queries run -- until it's time to give up. 1 hour.
    */
-  QUERY_TIMEOUT_IN_SECONDS(1800),
+  QUERY_TIMEOUT_IN_SECONDS(3600),
 
   /**
    * Log every N records.

--- a/src/main/java/gov/ca/cwds/neutron/enums/NeutronSchedulerConstants.java
+++ b/src/main/java/gov/ca/cwds/neutron/enums/NeutronSchedulerConstants.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.neutron.enums;
 
 /**
- * Common Neutron constants for Quartz.
+ * Neutron constants for the Quartz scheduler.
  * 
  * @author CWDS API Team
  */

--- a/src/main/java/gov/ca/cwds/neutron/jetpack/JetPackLogger.java
+++ b/src/main/java/gov/ca/cwds/neutron/jetpack/JetPackLogger.java
@@ -37,12 +37,14 @@ public class JetPackLogger implements ConditionalLogger {
    * @param args
    * @return
    */
+  @SuppressWarnings("unchecked")
   private Object[] collect(Supplier<Object>... args) {
     return Arrays.stream(args).map(Supplier::get).collect(Collectors.toList())
         .toArray(new Object[0]);
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public void trace(String format, Supplier<Object>... args) {
     if (isTraceEnabled()) {
       logger.trace(format, collect(args));
@@ -50,6 +52,7 @@ public class JetPackLogger implements ConditionalLogger {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public void debug(String format, Supplier<Object>... args) {
     if (isDebugEnabled()) {
       logger.debug(format, collect(args));
@@ -57,6 +60,7 @@ public class JetPackLogger implements ConditionalLogger {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public void info(String format, Supplier<Object>... args) {
     if (isInfoEnabled()) {
       logger.info(format, collect(args));
@@ -64,6 +68,7 @@ public class JetPackLogger implements ConditionalLogger {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public void warn(String format, Supplier<Object>... args) {
     if (isWarnEnabled()) {
       logger.warn(format, collect(args));
@@ -71,6 +76,7 @@ public class JetPackLogger implements ConditionalLogger {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public void error(String format, Supplier<Object>... args) {
     if (isErrorEnabled()) {
       logger.error(format, collect(args));

--- a/src/main/java/gov/ca/cwds/neutron/launch/listener/NeutronBulkProcessorListener.java
+++ b/src/main/java/gov/ca/cwds/neutron/launch/listener/NeutronBulkProcessorListener.java
@@ -46,7 +46,7 @@ public class NeutronBulkProcessorListener implements BulkProcessor.Listener {
     if (response.hasFailures()) {
       // NEXT: use CindyBulkResponse for per record error details instead of toString().
       final String failure = response.buildFailureMessage();
-      LOGGER.error("\n\t\t >>>>>> BULK FAILURES??? status: {}, errors: {}\n", response.status(),
+      LOGGER.error("\n\t\t >>>>>> BULK FAILURES! status: {}, errors: {}\n", response.status(),
           failure);
       flightLog.trackBulkError();
     }

--- a/src/main/java/gov/ca/cwds/neutron/rocket/LastFlightRocket.java
+++ b/src/main/java/gov/ca/cwds/neutron/rocket/LastFlightRocket.java
@@ -245,7 +245,7 @@ public abstract class LastFlightRocket implements Rocket, AtomShared, AtomRocket
    */
   @Override
   public void doneRetrieve() {
-    LOGGER.info("\n\t\t *********** RETRIEVAL DONE ***********\n");
+    LOGGER.info("****** RETRIEVAL DONE ******");
     getFlightLog().doneRetrieve();
   }
 
@@ -262,7 +262,7 @@ public abstract class LastFlightRocket implements Rocket, AtomShared, AtomRocket
    */
   @Override
   public void doneIndex() {
-    LOGGER.info("\n\t\t *********** INDEXING DONE ***********\n");
+    LOGGER.info("****** INDEXING DONE ******");
     getFlightLog().doneIndex();
   }
 

--- a/src/main/java/gov/ca/cwds/neutron/rocket/PeopleSummaryLastChangeHandler.java
+++ b/src/main/java/gov/ca/cwds/neutron/rocket/PeopleSummaryLastChangeHandler.java
@@ -123,7 +123,6 @@ public class PeopleSummaryLastChangeHandler extends PeopleSummaryThreadHandler {
     Transaction txn = null;
     List<EsClientPerson> recs = null;
     int totalClientAddressRetrieved = 0;
-    freeMemory();
 
     // ---------------------------
     // RETRIEVE DATA
@@ -268,7 +267,6 @@ public class PeopleSummaryLastChangeHandler extends PeopleSummaryThreadHandler {
       LOGGER.info("check access limitations");
       addAll(results); // push to normalized map
       results = null; // free memory
-      freeMemory();
 
       // Remove sealed and sensitive, if not permitted to view them.
       if (!deletionResults.isEmpty()) {

--- a/src/main/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandler.java
+++ b/src/main/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandler.java
@@ -82,7 +82,7 @@ public class PeopleSummaryThreadHandler
     final FlightLog flightLog = getRocket().getFlightLog();
 
     // NOTE: Assumes that records are sorted by group key.
-    while (!rocket.isFailed() && rs.next() && (m = rocket.extract(rs)) != null) {
+    while (rocket.isRunning() && rs.next() && (m = rocket.extract(rs)) != null) {
       CheeseRay.logEvery(LOGGER, ++cntr, "Retrieved", "recs");
       if (!lastId.equals(m.getNormalizationGroupKey()) && cntr > 1) {
         normalize(grpRecs);

--- a/src/main/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandler.java
+++ b/src/main/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandler.java
@@ -88,10 +88,10 @@ public class PeopleSummaryThreadHandler
   @Override
   public void handleMainResults(ResultSet rs, Connection con) throws SQLException {
     int cntrRetrieved = 0;
+    int cntrNormalized = 0;
     final FlightLog flightLog = getRocket().getFlightLog();
 
     { // scope brace
-      int cntrNormalized = 0;
       EsClientPerson m;
       Object lastId = new Object();
       final List<EsClientPerson> grpRecs = new ArrayList<>(50);
@@ -101,7 +101,7 @@ public class PeopleSummaryThreadHandler
       // Retrieve.
       LOGGER.info("handleMainResults(): Retrieve client range");
       while (rocket.isRunning() && rs.next() && (m = rocket.extract(rs)) != null) {
-        CheeseRay.logEvery(LOGGER, 2000, ++cntrRetrieved, "Retrieved", "recs");
+        CheeseRay.logEvery(LOGGER, 5000, ++cntrRetrieved, "Retrieved", "recs");
         denormalized.add(m);
       }
 
@@ -175,7 +175,8 @@ public class PeopleSummaryThreadHandler
       rc.setActivePlacementHomeAddress(pha);
     } else {
       // WARNING: last chg: if the client wasn't picked up from the view, then it's not here.
-      LOGGER.warn("Placement home address not in normalized map! client id: {}", pha.getClientId());
+      LOGGER.warn("Client id for placement home address not in normalized map! client id: {}",
+          pha.getClientId());
     }
   }
 

--- a/src/main/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandler.java
+++ b/src/main/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandler.java
@@ -96,7 +96,6 @@ public class PeopleSummaryThreadHandler
       Object lastId = new Object();
       final List<EsClientPerson> grpRecs = new ArrayList<>(50);
       final List<EsClientPerson> denormalized = new ArrayList<>(FULL_DENORMALIZED_SIZE);
-      LOGGER.debug("handleMainResults(): Cursor name: {}", rs.getCursorName());
 
       // Retrieve.
       LOGGER.info("handleMainResults(): Retrieve client range");

--- a/src/main/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandler.java
+++ b/src/main/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandler.java
@@ -83,7 +83,7 @@ public class PeopleSummaryThreadHandler
 
     // NOTE: Assumes that records are sorted by group key.
     while (rocket.isRunning() && rs.next() && (m = rocket.extract(rs)) != null) {
-      CheeseRay.logEvery(LOGGER, ++cntr, "Retrieved", "recs");
+      CheeseRay.logEvery(LOGGER, 2000, ++cntr, "Retrieved", "recs");
       if (!lastId.equals(m.getNormalizationGroupKey()) && cntr > 1) {
         normalize(grpRecs);
         grpRecs.clear(); // Single thread, re-use memory.
@@ -125,15 +125,15 @@ public class PeopleSummaryThreadHandler
                 ClientSQLResource.INSERT_NEXT_BUNDLE));
         final PreparedStatement stmtSelPlacementAddress =
             con.prepareStatement(sqlPlacementAddress)) {
-      prepAffectedClients(stmtInsClient, range);
-      prepAffectedClients(stmtInsClientPlacementHome, range);
+      prepPlacementClients(stmtInsClient, range);
+      prepPlacementClients(stmtInsClientPlacementHome, range);
       readPlacementAddress(stmtSelPlacementAddress);
     } catch (Exception e) {
       rocket.fail();
       try {
         con.rollback();
       } catch (Exception e2) {
-        LOGGER.trace("NESTED EXCEPTION", e2);
+        LOGGER.trace("NESTED ROLLBACK EXCEPTION!", e2);
       }
       throw CheeseRay.runtime(LOGGER, e, "SECONDARY JDBC FAILED! {}", e.getMessage(), e);
     }
@@ -263,7 +263,7 @@ public class PeopleSummaryThreadHandler
         .forEach(n -> normalized.put(n.getId(), n));
   }
 
-  protected void prepAffectedClients(final PreparedStatement stmt, final Pair<String, String> p)
+  protected void prepPlacementClients(final PreparedStatement stmt, final Pair<String, String> p)
       throws SQLException {
     stmt.setMaxRows(0);
     stmt.setQueryTimeout(QUERY_TIMEOUT_IN_SECONDS.getValue()); // SNAP-709
@@ -276,7 +276,7 @@ public class PeopleSummaryThreadHandler
     }
 
     final int countInsClient = stmt.executeUpdate();
-    LOGGER.info("affected clients: {}", countInsClient);
+    LOGGER.info("Placement home clients: {}", countInsClient);
   }
 
   protected void readPlacementAddress(final PreparedStatement stmt) throws SQLException {

--- a/src/main/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandler.java
+++ b/src/main/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandler.java
@@ -67,7 +67,7 @@ public class PeopleSummaryThreadHandler
   /**
    * key = client id
    */
-  protected Map<String, ReplicatedClient> normalized = new HashMap<>(300119);
+  protected Map<String, ReplicatedClient> normalized = new HashMap<>(200117);
 
   public PeopleSummaryThreadHandler(ClientPersonIndexerJob rocket) {
     this.rocket = rocket;

--- a/src/main/java/gov/ca/cwds/neutron/util/jdbc/NeutronDB2Utils.java
+++ b/src/main/java/gov/ca/cwds/neutron/util/jdbc/NeutronDB2Utils.java
@@ -95,8 +95,8 @@ public class NeutronDB2Utils {
   public static boolean isDB2OnZOS(final BaseDaoImpl<?> dao) throws NeutronCheckedException {
     boolean ret = false;
 
-    try {
-      final Connection con = NeutronJdbcUtils.prepConnection(dao.grabSession()); // DO NOT CLOSE!!!
+    try { // DO NOT CLOSE SESSION/CONNECTION!! No try/catch with resources block.
+      final Connection con = NeutronJdbcUtils.prepConnection(dao.grabSession());
       final DatabaseMetaData meta = con.getMetaData();
       LOGGER.debug("meta: product name: {}, production version: {}, major: {}, minor: {}",
           meta.getDatabaseProductName(), meta.getDatabaseProductVersion(),

--- a/src/main/java/gov/ca/cwds/neutron/util/jdbc/NeutronJdbcUtils.java
+++ b/src/main/java/gov/ca/cwds/neutron/util/jdbc/NeutronJdbcUtils.java
@@ -22,6 +22,7 @@ import org.hibernate.jdbc.Work;
 import org.hibernate.query.Query;
 
 import gov.ca.cwds.data.BaseDaoImpl;
+import gov.ca.cwds.neutron.atom.AtomHibernate;
 import gov.ca.cwds.neutron.atom.AtomInitialLoad;
 import gov.ca.cwds.neutron.enums.NeutronIntegerDefaults;
 import gov.ca.cwds.neutron.exception.NeutronCheckedException;
@@ -333,7 +334,7 @@ public final class NeutronJdbcUtils {
    * @return default CMS schema name
    */
   public static String getDBSchemaName() {
-    return System.getProperty("DB_CMS_SCHEMA");
+    return System.getProperty(AtomHibernate.CURRENT_SCHEMA);
   }
 
   /**
@@ -467,7 +468,7 @@ public final class NeutronJdbcUtils {
       String[] partitions) {
     final int len = partitions.length;
     final int skip = len / partitionCount;
-    LOGGER.info("len: {}, skip: {}", len, skip);
+    LOGGER.debug("len: {}, skip: {}", len, skip);
 
     final Integer[] positions =
         IntStream.rangeClosed(0, len - 1).boxed().flatMap(NeutronStreamUtils.everyNth(skip))
@@ -504,7 +505,6 @@ public final class NeutronJdbcUtils {
       // ORDER: a,z,A,Z,0,9
       // ----------------------------
       ret.add(Pair.of(Z_OS_START, Z_OS_END));
-      // ret = initialLoad.limitRange(buildPartitionsRanges(4, partitions));
     } else {
       // ----------------------------
       // Linux or small data set:

--- a/src/main/java/gov/ca/cwds/neutron/util/jdbc/NeutronJdbcUtils.java
+++ b/src/main/java/gov/ca/cwds/neutron/util/jdbc/NeutronJdbcUtils.java
@@ -17,9 +17,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
-import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.jdbc.Work;
 import org.hibernate.query.Query;
 
@@ -35,6 +33,11 @@ import gov.ca.cwds.neutron.util.transform.NeutronStreamUtils;
 /**
  * JDBC utilities for Neutron rockets.
  * 
+ * <p>
+ * DB2 sorts results differently by platform due to native character sets. That is, {@code ORDER BY}
+ * does <strong>NOT</strong> order results the same way in Linux and z/OS! You've been warned.
+ * </p>
+ * 
  * @author CWDS API Team
  */
 public final class NeutronJdbcUtils {
@@ -44,6 +47,9 @@ public final class NeutronJdbcUtils {
   private static final String Z_OS_START = "aaaaaaaaaa";
   private static final String Z_OS_END = "9999999999";
 
+  /**
+   * Basic client identifier partitioning for z/OS.
+   */
   private static final String[] BASE_PARTITIONS = {"AeRTLuZ6WW", "A6y48OH3Ut", "BzaK4AmDfS",
       "B26CwOn9qX", "CvIYhuyCJt", "CY8r2uwEBI", "DsNAQ1W4l6", "DWQGOmFAzi", "EpKrO9a9xb",
       "ESH4wdQ02u", "Fmy2cMI0kW", "FN4JbQ0BFV", "GjekFiPEuJ", "GMSl4aH4wm", "HfvKXzA7rJ",
@@ -56,7 +62,10 @@ public final class NeutronJdbcUtils {
       "4u0U0MECwr", "4YRF9Dd70O", "5rOfwNO3gC", "5T7PS2j37S", "6oipPRSKDX", "6R6kaia0SL",
       "7ki4MYoAzi", "7NYwtxJ7Lu", "8guC2hG4ak", "8JpJrxB37S", "9cRG3VmH6i", "9GwwRzY7D3", Z_OS_END};
 
-  private static final String[] EXTENDED_PARTITIONS = {"AeRTLuZ6WW", "Ahg03Ap3Ez", "AkEfSN73RZ",
+  /**
+   * Extended client identifier partitioning for z/OS. Use for large jobs.
+   */
+  private static final String[] PARTITIONS_512 = {"AeRTLuZ6WW", "Ahg03Ap3Ez", "AkEfSN73RZ",
       "An1tg0144S", "AroiT1Z7OF", "Av2FphfBw8", "AzyEzYCFYI", "AC5wEdz9YH", "AG82rVX2KA",
       "AK6Qtf82LK", "AOv5WvzM5K", "ARUrOuS8Xz", "AVkHVOY99d", "AYNERiMCOB", "A24xxaN6bb",
       "A6zehUX30A", "A94Mn377OF", "BdzzZCiCFA", "Bg2L0ID36B", "Bkuv1Zh37S", "Bo6SRjV8fe",
@@ -143,6 +152,179 @@ public final class NeutronJdbcUtils {
       "9F3Mjaa9us", "9Jzi20936B", "9Oe3WLlBng", "9RDHqEFFTz", "9U4SXT86gX", "9YvgJqz49S",
       "91W4KCkALI", "96C1s5R30A", "997Da6t5dE", Z_OS_END};
 
+  private static final String[] PARTITIONS_1024 =
+      {"Aca36tZGdm", "AdRRWID5Jb", "Afyx2TR9Zp", "Ahfy9MT8SW", "AiV4DMD4zP", "AkCPFYvCf2",
+          "Amh3DXRB3p", "AnZYLRE9Zp", "ApIrZ1C2AW", "ArmA7yzEaC", "AufJuGu63O", "AvZYQIT30A",
+          "AxLrTc0H2T", "Azwa1Kf5xB", "ABf0yJoA3u", "AC2uRhi5ET", "AEJ2uhx1M7", "AG4dgoL3tZ",
+          "AJkS3g930A", "AK2lXsX36B", "AMKfaL57SU", "AOqBA3W9xb", "AP7GhID6eP", "ARPjYdq2kl",
+          "ATxUhPFDSs", "AVetix42Np", "AWYFM3m7NP", "AYFU6w7Acg", "A1dPodZ63f", "A2W7D52Ny6",
+          "A4HUbVs9oD", "A6rEyzJ5Dg", "A8cCSh75Q0", "A9VHUHKJVC", "BbErdtR07S", "BdpB8RILLm",
+          "Be7vxGvBuJ", "BgSiCUYGLZ", "BiAIuseG9P", "BkjDmsi5Aj", "Bl1OMG19ip", "BoUGYSsAS2",
+          "BqCi4eF3Qu", "Bsj8vObAJH", "Bt12tBC99d", "BvIIXFB30A", "BxqA7KW0Py", "By84prY6U9",
+          "BBsYoOb2Ld", "BDJyaUhDeC", "BFqMsblGF7", "BG9ezMMH4Y", "BISpDph43S", "BKA1hzV5Dj",
+          "BMjMcFA0mF", "BN22e3O5xB", "BPIYlKW046", "BRrSDYrKRD", "BS9KdyMEzB", "BV3aT4EERK",
+          "BXKiD2o1ze", "BZuNxgX43S", "B1eAt7NMYX", "B2XqfG1Bha", "B4IkQ8fCOq", "B6sOQt749S",
+          "B8db0pCCOl", "B9Wze4X6eV", "CbEDajO9TC", "CdpPzGJJ8m", "Ce9Fgm76x4", "ChsbTfwMWM",
+          "CjIhjlZ43S", "Clp2id5ALH", "Cm61PiF5DQ", "CoNiR935VY", "CqswmZdCqG", "CsaBNab30A",
+          "CtP5wrS5DU", "CvufA4pC1F", "CxaGiM2BNQ", "CyRL0KFCKo", "CBopndC717", "CC8g0BNE6M",
+          "CESIsfxGzG", "CGBal4i5Dk", "CIi06v03Yq", "CJ3cH2CGrR", "CLLXcwL36B", "CNLWEv0Bt6",
+          "CQlJPKOH6i", "CR6dl82Ht6", "CTQF0WU5om", "CVBE97pC5E", "CXlwQ8901S", "CY4yLrN43S",
+          "C0NoW4A5db", "C2wwmKx2TQ", "C4bCMVi0Z6", "C66aKEp4rh", "C8MFytt01S", "DaQlB9Y5TH",
+          "Ddp8ooj49S", "De7hdUrC96", "DgPzwSO6Au", "DixltN8GF7", "DkcZBlK6ob", "DlUiUPGCOB",
+          "DnCN6fz6V1", "Dpjalfd34A", "DqZ0JLS922", "DsIdBWPF4m", "DvzRBPL5Dg", "DxhJydA0P3",
+          "DyXF1XF8kK", "DAF4ULNHc7", "DCpkvjT5Jb", "DD7t2L0FRj", "DFQf2Av6eP", "DHCGI792Jf",
+          "DKtMRZDA15", "DMdAnGj7PC", "DNZMyyEA16", "DPKPoCc6AD", "DRvdvYS6UO", "DTgMABF0AH",
+          "DU1tn7PBjD", "DWMwR0e4F3", "DYyfnPN34A", "D0h2Yvn03d", "D2k7uaeCmn", "D32Kg5f9yb",
+          "D5IZjs4H9Q", "D7tmQdz6L5", "D9btFIH04F", "EaSxRwJ6L0", "EcBLM1MJkK", "EeiLtWl6vU",
+          "EfZSzNj78v", "EhJHSwkEfU", "EjpQxkUBYW", "Ek7bqZOBm2", "EmO3HDMCHt", "EpIcBkG6V9",
+          "ErrKRMO2Un", "Es9AzIQAs8", "EuSWxPtH6i", "EwCxwQMJ5y", "EykSJGx9Bz", "Ez1WazS15l",
+          "EBKcYe6EaC", "EEDD0c544S", "EGqaiTN2LR", "EH9JbEI3b4", "EJTXhWI2SP", "ELFkShl7OF",
+          "ENpprtH0AH", "EO9vReAAVR", "EQTHV5t99d", "ESDAcYD14N", "EUmNguZ26h", "EXjmXHS5TH",
+          "EY0VSdw5DQ", "E0JthFS6oG", "E2qrq326yv", "E38UnrN54S", "E5N1mxH5Ov", "E7x5WmX8qt",
+          "E9g4TXaMh6", "FaYdGnR43S", "FcFBHdJ30A", "FenCE7743S", "Ff5Zfav6uI", "FhRESxLIUP",
+          "FkKL0qo196", "FmtsqCf30A", "FobxNbU5Dg", "FpTVWiC75R", "FrDlSxt5xu", "FtmD5G23UZ",
+          "Fu55aan30A", "FwOYWrR36B", "Fyy3M4tEuS", "FAhteUCAR1", "FBXlWOP34A", "FDGqqL66cS",
+          "FFlJ1PiaaK", "FG1DYUj33A", "FIKGRBM9Eo", "FKrDDvzBVn", "FL8WzaaDJB", "FNNIsJx5AH",
+          "FQj8xd1C2O", "FSqWUMfOy2", "FT8AZV8Bha", "FVRmspd3sQ", "FXy97bv4t0", "FZhXge149S",
+          "F0ZlREW2Ke", "F2H5vTF41S", "F4qrV0E2xc", "F59swEaGj1", "F82VSOv30A", "GaJ6iLaCco",
+          "Gde483I72f", "GfpQGjF2AW", "Gg9cnZAAzW", "GiTvKAT40S", "GkCr2bOF9L", "GmjUMbt9ge",
+          "Gn5QUVP6UO", "GpPLu4663f", "GryWOOL4tA", "GtjshV8JFj", "Gu7wm4A192", "GxV8JeW21w",
+          "GzCGm49197", "GBisMcp7g2", "GCYEgpr4uJ", "GEFt5O507S", "GGh73G49j5", "GHYE5a76eP",
+          "GKifKwD36B", "GMAMamFGLw", "GOhxriD43S", "GPZmtfE3aj", "GRJdJ6B6DS", "GTstt6C4tA",
+          "GVcTRtF7l7", "GWU6yii6cu", "GYBW5ej24F", "G0CfuwDBsj", "G3b0n6v2ej", "G4SOFmPA3u",
+          "G6yy6wT30A", "G8dYubl9Eo", "G9RVsb26VO", "HbARTu0GzA", "HdjRMVy6cS", "He44vPT9a5",
+          "HgOL2Ib3Rp", "HizWIdO4si", "Hkj7Qn50LU", "Hl5ISaQ5vN", "HnTjHEyFjg", "Hqo54ht2hL",
+          "Hsu7tqlFsf", "HucGDL1Bha", "HvUjMMZ2Ke", "HxBPSbp3PK", "HzjbTNRAzi", "HA0fV8z36B",
+          "HCHzTCj1Gz", "HFzJdbz6aI", "HHg2uqz8Gq", "HIZi8Us4Zx", "HKFIIX49Zp", "HMouhec10S",
+          "HN6e3Fqz33", "HPMPpj26SD", "HRv98k0F7i", "HTeMPIx5ij", "HUTRMZP5Dm", "HW8SgSM9hu",
+          "HZw5k9hAmr", "H1e4XDt37S", "H2V5ze55VY", "H4BIsVg8Ow", "H6iJV10199", "H7XKExRBV3",
+          "H9EKYUr2bX", "IbobEDh34A", "Ic8MEhyGzs", "IeUEOP337S", "IgF8wEg5Oc", "Iiqgslt54S",
+          "Ilmdyvz3sC", "Im4bFlqDyB", "IoMTFZ5Cws", "IqvNU0L2N2", "Iscj9Ak1Yc", "ItSeE0LDN8",
+          "IvAQFaz30A", "IxkdB22CQa", "Iy1fh3p54S", "IALJka19j5", "ICqqZHP1Kz", "ID6XBjN30A",
+          "IFNoq8Y4qv", "IHtdvnI5Ds", "IJaesEDCfU", "IKPFBo137S", "IMvdTmx3hy", "IObRgBP6eV",
+          "IPSJJuGHJG", "ISMoyqRN09", "IUwrp7vI5J", "IWgTBGoA6L", "IX1BAXj0RM", "IZN8R6o043",
+          "I1vbDINBm3", "I3dT8yH5Dj", "I4Uc5ZZ0NY", "I6CakUNCfj", "I9obxLOLUU", "Jbdw3dZ43S",
+          "JcVkpXaFX0", "JfNkJ21BjD", "Jhu2a49197", "JjcM7AB4Zy", "JkVM3beDDC", "JmCPSTyAcg",
+          "JolbtcFBm5", "Jp3W0STOy2", "JrLSqKpEaC", "JtuQZwx2Ld", "JvcbeOT6ob", "JxsUYGf3Lv",
+          "JzLcfMk2hL", "JBtFYMv4oz", "JDdKPnq2vI", "JEVZ7h55wz", "JGEJPGWBm2", "JInW2Bd6cS",
+          "JJ7Q9YAAbA", "JMQtXOc5Cx", "JOIA2Jw2qt", "JQoBxLW9of", "JR50RsuCrw", "JTOccDxDDF",
+          "JVuDdWULIQ", "JXdDuanCCS", "JYR8QCsNqb", "J0BxFVI6d0", "J24uLCm6cu", "J49MXmn5Fe",
+          "J6TeSE55Ch", "J8BrxVh07S", "KakSZ1cDNc", "Kb3QAEfJ1J", "KdLP8F8DNc", "KfsvR6HA2T",
+          "KhanfxeDsF", "KiSlQHPB0R", "KkBUCkU8eE", "KmjX56XKbI", "Kn2XSbJKE8", "KpKVm2z37S",
+          "KsCErrd37S", "KumpyjlAli", "Kv5tssDDzS", "KxPogPF5Fe", "KzyDZoJMPq", "KBhRRMh4nn",
+          "KC2oN484Zy", "KEK3Ke06f4", "KHC39iH0V1", "KJlcKBCAUi", "KK0OxmXEZD", "KMG2ppP9mp",
+          "KOofsqT5ES", "KP4Lk0z2qR", "KRLfNl6Bp1", "KTqyqig10S", "KU77oLE8AK", "KWPc1rl2Rw",
+          "KZwBfvBA16", "K1pXOCL5Fe", "K28T2Gp7g2", "K4Szr19M9L", "K6Bjpfc6bb", "K8lpaMb36B",
+          "K96Wd6bOyk", "LbO6fG18SL", "Ldv2fBvBKy", "Lfc6ngmATF", "LgTFJaE6gX", "LizVjs75D9",
+          "LkgEuOML8Q", "LnauVof30A", "LoUFhx337S", "LqDmaS07l7", "LspvMsD01S", "Lt9ACu63Lw",
+          "LvThTDm10S", "LxDX6ht37S", "LzoOxAHChq", "LBNqTkb3ax", "LDvIk0SMXK", "LFdF2Sy5Fe",
+          "LGUaZO6192", "LIzez7n5Cx", "LKfBYnA0KD", "LLWoPzo5VY", "LNBJaQP5Df", "LPiai3t37S",
+          "LQZ5F8tC3m", "LTq3dnX2k5", "LVw2ztm9j6", "LXd5EBfAwr", "LYU7U156DS", "L0Cu0sF5Dk",
+          "L2nCNHt30A", "L37zxL394v", "L5QUk9k4nn", "L7BVsMV6uL", "L9LEYzS3c0", "MbwOfw2AnH",
+          "Mdeami9Eh4", "MeVaftd8xK", "MhNfitN43S", "MjtigWOFty", "MlaiYcoDNc", "MmRZzHt37S",
+          "Moz81yBC4X", "MqjXhfIMRY", "Mr2Gdsn2LK", "MtJIiUuGzs", "MvqTHxR30A", "Mw7uL4i4zY",
+          "MzN5FX042E", "MBFqGqT9A2", "MDnLZVPCnO", "ME6NCJl37S", "MGN9zeT7CO", "MIvH8450TZ",
+          "MKdg0x4C7Y", "MLU0DtcDjK", "MOMk53c5Do", "MQvSkicMP0", "MScAYJo5xu", "MTVFg1sMiP",
+          "MVDwun46oG", "MXlm8xi0kC", "MY4DmVF6qq", "M0NNF8FMxR", "M2znnTLBrf", "M5sYUux3hi",
+          "M7drznvMQk", "M8TOV9d30A", "NbkdCIE4tA", "Nc0Hfsr3M6", "NeJe5mFBp6", "Ngp86K90Ut",
+          "Nh42QYj43S", "NjOiUa2Kye", "NlwHVOc9ck", "NncP1bq6nO", "NoRD3R56lq", "NqyWnVR37S",
+          "Ns0PH7p01S", "NvadBIu5X0", "NwSDYfL4kv", "NyywnIM6qG", "NAgHboS9jA", "NBZvmzaG43",
+          "NDE7JxEFfE", "NFlVyu930A", "NIeTUBk2ha", "NJYNdnmFNu", "NLGURJsBaA", "NNqIPcz8aR",
+          "NO77ain07S", "NQNHIRe1mN", "NSwZNob7Jo", "NUegMG28mw", "NVWdAZdC1a", "NXEGfRs4F3",
+          "NZMIkle7XZ", "N1zkHwL3F8", "N3jMnsL2LR", "N419H8b30A", "N6L8phZ5Ch", "N8tHrSgAQf",
+          "OaaEf1s0kC", "ObRqiHoC8S", "Odw0l3l2My", "OfeRfkS5DT", "OgVtDgK5q5", "OiA0qpO73p",
+          "OkhqS6uGPM", "OlYdRfD6gX", "OoTylzt2EC", "Oqy7vYw5dM", "OsfSTrqCMi", "OtZdVzJBn5",
+          "OvGx5PzAAz", "OxogZ9t34A", "Oy6idx75q5", "OAN9fvRPTl", "ODLPHPi1M7", "OFw1GA305E",
+          "OHfyFpy10S", "OIZbWwD01S", "OKJMU7x3hi", "OMug8O15Cx", "OOchICzAOM", "OPVt29O9A4",
+          "OREr2R0Bdr", "OTCh9V0C1a", "OWg3m8oCd6", "OXYg6hl30A", "OZEVZggBn5", "O1m49V39cz",
+          "O26XiyH2xh", "O4QRltQCnH", "O6w1h7zMtC", "O8b1MmfB3r", "O9VDSMu3Ek", "PbCVLhy199",
+          "PdjA2Ia4D9", "PeYUv4gJfK", "PgS74aXD8q", "Pjy3KaL2vI", "Pldz8Hy26h", "PmTqrTQ0RM",
+          "PoAeapZA17", "PqfIOsk3qY", "PrUTsC937S", "PtBAzmO7NP", "Pvf2KMV6V1", "PwWLp9WLAb",
+          "PyB8ld75Yk", "PALyGqjO0s", "PCvSX62DTW", "PEe0Xir30A", "PFZbp570Yt", "PHKFxlvDxO",
+          "PJrXpZ0GZY", "PLcHRAK4F3", "PMWjW7R7l7", "PPIkabM6a7", "PRBwmOaAwU", "PTjs5u7D55",
+          "PU1fepf8iJ", "PWJ08KCMR8", "PYqqF6QEXp", "PZ56RKT01S", "P1MBSSI7B5", "P3ua4juBGv",
+          "P5CNhGj36B", "P79H63p21w", "P9Tvy5J197", "QcEoeurHj9", "QexTz0kAmr", "QgfJSFO5yt",
+          "QhZVoHe5Du", "QjIrZ6E5Fx", "Qlo3v7lH7J", "Qm60W4QFUU", "QoNKdFRDEx", "QqwZyjKKiq",
+          "QsgLeCpAzW", "Qvak9wD4kN", "QwO2d0gFNu", "QyxI6sL5Le", "QAe5fD5CVF", "QB0o4eTCfj",
+          "QDK7pqO9cm", "QFtQayD5Cw", "QHdXvqT37S", "QJYyWAN1mN", "QLPSLET5Cx", "QNyOdLTEA7",
+          "QPgrDSPE0v", "QQWn2F926z", "QSC6gHJBre", "QUkEQS68p7", "QV3nDSf2kl", "QXKRryz197",
+          "QZsvKky7bU", "Q1XShwQ4tA", "Q3H86M501S", "Q5ssLxxDSt", "Q7bYsmUMlM", "Q8WeDas2r5",
+          "RaEVOrKJp6", "Rcm0jeGNy0", "Rd5tbDl36B", "RfOO5au1X9", "RhyAtqlKYJ", "RjiM6PVOph",
+          "Rk0V29f5UG", "RmJZ1Af8ZL", "RppDJSm2OJ", "RrkX2kz01S", "Rs0tiAD7D3", "RuH8NhD16S",
+          "RwmiSzF8IJ", "Rx0eV7cO78", "RzGsZMM1Ij", "RBmgIjf0BN", "REf1Ehu3eH", "RFX9nzx5UB",
+          "RHFvJtC5qH", "RJncs5RD90", "RK4E1t6Ans", "RMLTlQ5Opb", "ROt6ZONBXe", "RQbHTVm2Mq",
+          "RRS0bRlFx7", "RTAvrlp15A", "RVH1bf642E", "RYdyuA95Ds", "RZWlRbW5DT", "R1DrjG536B",
+          "R3jxDWZH4Y", "R40PbkwEO2", "R6IeWjW4k5", "R8n2grlDxO", "R94gLQn36B", "SbOEW6GNQw",
+          "SdyKDKS6L5", "Sfjt5UO3Em", "Sg3zMX87l9", "SjrJsMjDB0", "SlCVquf046", "SnlowoiDha",
+          "So2SazC5Cp", "SqKlHqz37S", "SsprRD730A", "St6NX4lGsk", "SvOocKX38A", "SxvO2SgDdh",
+          "SzdT45w1B5", "SAUr3pI6AD", "SCCk7AA2dT", "SEkq73H4wm", "SF1uf1F07S", "SHIxQWNC42",
+          "SJrd52YCVp", "SK89oBt43S", "SMSb12KFns", "SOBeK6k5Du", "SRtYylV5q5", "STeEuGs5Du",
+          "SU0d0I35xB", "SWJhGcgMF8", "SYtkXk5G0z", "S0c6qEEKFQ", "S1T4Lxu77R", "S3zSDyW2U6",
+          "S5goo51GzG", "S68sAHRA17", "S9OzxKiBDj", "Tbzs6pm3oq", "Ter3W9z2Nl", "Tf9wEcS6i8",
+          "ThQZcQWH0A", "TjxK4Zd43S", "TlhfMso3Xv", "TmZ097jDNc", "ToGKYV0BKw", "Tqn2HUXAzW",
+          "Tr5Rj6a6xC", "TtMEghFC4r", "Tv89Puf0kW", "TykXeoD30A", "Tz3tthD8fE", "TBL1vDn6p7",
+          "TDs3wN00MM", "TFbsELWGUs", "TGScLLxMF4", "TIAle2mI6B", "TLqo6Wv01S", "TM99n7a4hE",
+          "TOWJuin44S", "TQFYRju2vI", "TSqC1ysz19", "TUazrBB43S", "TVVAoAk199", "TXETopd30A",
+          "TZpdRPPC42", "T07bqvx36B", "T3WVEwy45J", "T5DTVl9IVF", "T7jigj343S", "T8ZpfSW64q",
+          "UAF9Wvn8Jb", "UCpEeKf36B", "UD7hqhl37S", "U1M7MhUBm2", "U3v8Spe6bm", "U5dpT9NJmZ",
+          "U6UOomQ10S", "U8B2j6bAnE", "0a01y4H6d2", "0dgu6UGC42", "0eZfEPp07S", "0gKvSNvFJA",
+          "0it3D9h8qa", "0kfx71G5Du", "0l2bfRZ1mC", "0nMMf0j36B", "0pxIDxZ2ex", "0ripWcoBQB",
+          "0s2OjjkAcg", "0vVKrpJGmy", "0xDSnbP5dU", "0zj3O3l37S", "0A22gSeCpS", "0CLeIMt4nn",
+          "0EsGRij30A", "0GalXPSPRS", "0ItoNE42U6", "0KLrRSKEzB", "0Mvexes4wm", "0OfD6bl0KD",
+          "0PWIKBiA6L", "0RE9aZV4gP", "0TmsOM05EE", "0U6A4bC4nd", "0WOwzFcFLP", "0YyiVz26Au",
+          "00fsqa82SP", "01XIFBdGdQ", "03GVwip5RC", "05nnMXZ41S", "065wTg64zP", "08Qvoql6sl",
+          "1az04JtJx3", "1clSLQr4D9", "1d7c4iJ5q5", "1fRlQmB06Q", "1hCVijpFyl", "1jltVjd30A",
+          "1k5qj6LI4N", "1mNUevu9A4", "1pHDVI32Ld", "1rqOv1l9mp", "1s9lI6TJPT", "1uQZbrsC42",
+          "1wxpC4X37S", "1yfLqOY6v3", "1zXKtUp5om", "1BQJL8s10S", "1EBkDxZ37S", "1GjDHQmBm4",
+          "1H2rh4c5DT", "1JJdFgf92i", "1Ls0ILNDq8", "1NbIVaL4rN", "1OUfc8M3dA", "1QEXG9V9dr",
+          "1Sm6Qgz41S", "1T5NayQBDI", "1W0utrl30A", "1YKyrPV37S", "10vTcn315A", "12fnSC96ob",
+          "13YhNgn43S", "15F3NRLFfE", "17o5qkN5gH", "187fB7ZDdh", "2aPkkAgCxs", "2cBMZk6C1a",
+          "2el8UJX4nn", "2f7X0lu5gS", "2ispzylKRt", "2kK2jNy1DY", "2muRNis10S", "2oby2yk2SP",
+          "2pTJdxh5Du", "2rCujv4BLr", "2tl6UN45pf", "2u3WD6MBn5", "2wMZuOoDjS", "2yvs6YqC5M",
+          "2AcWKMnD7r", "2BTeM1YBzd", "2DCJr6K91i", "2FlazGg9us", "2G3zJ5P4wm", "2IKp9xIChq",
+          "2KrVNe05X8", "2L94yXi65j", "2NRndfPB3q", "2QH2MeS42H", "2StdWyl7D7", "2Uejk3U2vI",
+          "2V2YAAT33A", "2XMS3IY6cS", "2ZwYD6L4p3", "21eV25z2O2", "22WQ3G536B", "24E0CE0Jx4",
+          "27g14L726z", "29hDU5B36B", "3aZKrBeMKG", "3dTGR3Q3Xv", "3fC1NNU3Ju", "3hlG6txHt7",
+          "3i39JjFC8p", "3kMUkLqHwr", "3mvF4EXAPX", "3ocVGTr5nH", "3pVHYbcG0k", "3rD9vef59R",
+          "3toQDvm6mi", "3wlSCJ96bJ", "3x5LP039mp", "3zOykrR2KA", "3BwaMsL43S", "3DcNgbCGi9",
+          "3ETlHv3AQf", "3Gyz7Vp1LU", "3Ie1RGiBm3", "3KXBGbp197", "3MTufNbBS0", "3OFjSFK2Un",
+          "3QpG8blB3b", "3SbBF7y5Ds", "3TVwkd1CR3", "3VELCwWMPo", "3Xp1YH8Awr", "3ZcXMp9DNc",
+          "31WllAH33A", "33PLZ6ZFhE", "35yNgyNHcP", "37d6fF60P3", "38VIICW0Nn", "4aBjbnk9Z4",
+          "4cjtFrBLlN", "4d3dshNCnH", "4fPuDIl5yN", "4hyYjxW9gv", "4jieyRB2Np", "4kZWcgp63f",
+          "4mKo17C06Q", "4oAH2ph4Zl", "4rl9G8r8kF", "4s7bLIf36B", "4uObuXtACq", "4wAQufD7PC",
+          "4yjCbK6199", "4z3uKDR3Or", "4BNDZ961Wb", "4D9g5JJ36B", "4GojxJh2OJ", "4H4uCec6zK",
+          "4JNiYD336B", "4Ls7mXmJ1k", "4M7yomh5Cn", "4ORKNWwAWR", "4QzTsOH36B", "4SgV6kEEfU",
+          "4TXFxIf6jR", "4VFlyOD2qt", "4YzIfuyDcX", "40gPITy5Oi", "41Y5LYAIu0", "43H7KyI2vu",
+          "45rWUDaKlc", "47aUn11N6u", "48SPzZ12S9", "5aCjdJW9NQ", "5ckbwLv4mv", "5d2nM0XJEF",
+          "5fMtGE53tM", "5huVRpp3SL", "5j3kdUjHcP", "5l9AOh96VR", "5nTP3Y1GTf", "5pEgrbuKWV",
+          "5rmhu0v34A", "5s6cmzsAEx", "5uQMrYX43S", "5wCNBg22QH", "5ynvg77BG3", "5z8cbWaB42",
+          "5BL8zIqMtC", "5Duxkcy94v", "5Fa2C6z7PC", "5GStuHR43S", "5IzjQm26mW", "5KeEanoCpS",
+          "5LVHhB65xC", "5NBY4Ly5rb", "5PijBmZCbt", "5Scmbwn6gX", "5TU6oLp37S", "5VEtOhF40S",
+          "5XmMZIOAzf", "5Y6kUb83UM", "50OrE0H44S", "52yUD1V30A", "54i65GdC96", "553Tz2F9so",
+          "58qyZTl34A", "6aHacr4199", "6cqmaUR21w", "6fkUZy6EDF", "6g7iedJ2k5", "6iSV0uC7U4",
+          "6kEtF9WM5K", "6mpa27Q4m3", "6ocazrT5Df", "6pV2CoTDOk", "6rDCiYd4nn", "6toUmJt36B",
+          "6u9RQv7Lch", "6xU72yTD3U", "6zNbiV85Ps", "6Bu16yh2uR", "6DdaWRe2rU", "6EUjDb80ZX",
+          "6Gzva1C191", "6IgPttc3ht", "6JZmKkcBgW", "6MTirUdIfU", "6OzVdEG9dT", "6Qgl5SkCPl",
+          "6RWoz3Z54S", "6TDuXC556F", "6Vj0cci0Ut", "6W3noIRChq", "6YKbYQxAzW", "60rc7mA9q0",
+          "63j742lKyJ", "6442jZ45mG", "66MXlu56cS", "68tIqHJ01S", "7acBOuh5Ds", "7bUzCwJ2JJ",
+          "7dB8DWU3gC", "7fkgnUp7ir", "7g2GPrRP9Q", "7iKlphp887", "7kr8khv1zr", "7l94uPg5vN",
+          "7nTD0M52en", "7pBfh87FKI", "7suDZuj36B", "7uedii99Zp", "7vWWLlH99d", "7xFpfnrGLk",
+          "7zpQ73VG6l", "7BaezXWDga", "7CStRVvH0A", "7EKOQIl1DY", "7HzVpoLJKg", "7Jje7Dl37S",
+          "7K1GsJh6cS", "7MLnTH730A", "7OtsTlRH30", "7QbyJPSALH", "7RWUwGi3oq", "7THAiBxGrw",
+          "7VqfNHYAF8", "7XaBecN1aS", "7Z4rEsbCZO", "71NwKr75DL", "73weGcxH3U", "75fQGkW5D8",
+          "76Zq2zK9Vh", "78IaWsKC42", "8arBloT9Uu", "8cae78L30A", "8dRacCt8jr", "8fyYq8H36B",
+          "8hhXi5r06Q", "8i3ylvO5DT", "8k58YZTAF8", "8nDsH8n2NJ", "8pm9PqD30A", "8q5qdyD2bO",
+          "8sNnfpz4kN", "8uxjs5B15A", "8wgYtDG5DB", "8xZObFU0kC", "8zJIKrz5Df", "8BNotGrEfU",
+          "8DxJV1o2qT", "8Fg4sGQE1P", "8G2k9N372f", "8ILVpdQGgG", "8KuVX7d64h", "8MdXWPqCrw",
+          "8NXQAWfAzZ", "8PGi0KQM39", "8Roo39B2Nd", "8UiTs29COp", "8V0fDICNxt", "8XItjhE2LR",
+          "8ZoRvJ8CVp", "8071lPp3fm", "82Qc5k1A16", "84x1G4MEfU", "86hEr0D30A", "871qsOmAon",
+          "9aAtMtF30A", "9ciePCX1Gz", "9dZdAC7Bre", "9gPsXKtAu7", "9iAciQr30A", "9khRhxL0RH",
+          "9lZaYQaB7S", "9nG6C9J37S", "9ppKzOj36B", "9q7zsHr4p3", "9sPiX9IKFN", "9uvY5u06wK",
+          "9weYuKv36B", "9yxHKHLDeC", "9ARtjub07S", "9CDjJrX5ae", "9EnOhaj30A", "9F9op9738A",
+          "9HTZMDI2cc", "9JEbS9t5Do", "9Lo4MUg8Op", "9OiueMl26h", "9PZjuNK9oD", "9RGzOXT78h",
+          "9TpjASA4ez", "9U7EikE2en", "9WQzzdJ0Ur", "9YxdT1t37S", "90frs1t0Ut", "91YYq1jBFV",
+          "94klpEG2cD", "96Egptr6Nh", "98oXLe75Us", "998wqSDI6s", Z_OS_END};
+
   private NeutronJdbcUtils() {
     // Static utility class.
   }
@@ -152,23 +334,6 @@ public final class NeutronJdbcUtils {
    */
   public static String getDBSchemaName() {
     return System.getProperty("DB_CMS_SCHEMA");
-  }
-
-  /**
-   * Steal a connection from a Hibernate SessionFactory.
-   * 
-   * @param sessionFactory Hibernate SessionFactory
-   * @return database Connection
-   * @throws SQLException on database error
-   * @deprecated prefer method {@link #prepConnection(Session)}
-   * @see #prepConnection(Session)
-   */
-  @Deprecated
-  public static Connection prepConnection(final SessionFactory sessionFactory) throws SQLException {
-    final Connection con = sessionFactory.getSessionFactoryOptions().getServiceRegistry()
-        .getService(ConnectionProvider.class).getConnection();
-    NeutronJdbcUtils.enableBatchSettings(con);
-    return con;
   }
 
   /**
@@ -386,7 +551,7 @@ public final class NeutronJdbcUtils {
    * @return partition range pairs
    */
   public static List<Pair<String, String>> getPartitionRanges512() {
-    return buildPartitionsRanges(512, EXTENDED_PARTITIONS);
+    return buildPartitionsRanges(512, PARTITIONS_512);
   }
 
   public static List<Pair<String, String>> getCommonPartitionRanges4(
@@ -408,7 +573,12 @@ public final class NeutronJdbcUtils {
       @SuppressWarnings("rawtypes") AtomInitialLoad initialLoad) throws NeutronCheckedException {
     // Off by one. Close enough
     // However, "close" only counts in horseshoes (outdoor game), hand grenades, and hydrogen bombs.
-    return getCommonPartitionRanges(initialLoad, 511, EXTENDED_PARTITIONS);
+    return getCommonPartitionRanges(initialLoad, 511, PARTITIONS_512);
+  }
+
+  public static List<Pair<String, String>> getCommonPartitionRanges1024(
+      @SuppressWarnings("rawtypes") AtomInitialLoad initialLoad) throws NeutronCheckedException {
+    return getCommonPartitionRanges(initialLoad, 1024, PARTITIONS_1024);
   }
 
   public static void enableBatchSettings(final Session session) {

--- a/src/main/resources/jobs-cms-hibernate.cfg.xml
+++ b/src/main/resources/jobs-cms-hibernate.cfg.xml
@@ -10,8 +10,8 @@
 		<property name="hibernate.temp.use_jdbc_metadata_defaults">false</property>
 		<property name="hibernate.connection.driver_class">com.ibm.db2.jcc.DB2Driver</property>
 
-		<property name="connection_pool_size">2</property>
-		<property name="hibernate.connection.pool_size">2</property>
+		<property name="connection_pool_size">4</property>
+		<property name="hibernate.connection.pool_size">4</property>
 
 		<property name="show_sql">true</property>
 		<property name="format_sql">true</property>
@@ -28,42 +28,49 @@
 
 		<property name="hibernate.connection.connectionTimeout">1000000</property>
 		<property name="hibernate.connection.loginTimeout">1000000</property>
-		<property name="hibernate.connection.keepAliveTimeOut">60000</property>     <!-- seconds? -->
-		
-		<property name="hibernate.connection.enableRowsetSupport">1</property>
+		<property name="hibernate.connection.keepAliveTimeOut">3600</property>     <!-- seconds -->
+
+		<!-- Turn off Hibernate caching: -->
 		<property name="hibernate.connection.autocommit">false</property>
 		<property name="hibernate.cache.use_query_cache">false</property>
 		<property name="hibernate.cache.use_second_level_cache">false</property>
 		<property name="hibernate.connection.isolation">1</property>
 		<property name="hibernate.connection.provider_disables_autocommit">false</property>
-		<!-- <property name="hibernate.connection.allowNextOnExhaustedResultSet">1</property> -->
 
 		<property name="hibernate.connection.sqljAvoidTimeStampConversion">true</property>
 		<property name="hibernate.jdbc.time_zone">America/Los_Angeles</property>
 
+		<!-- C3P0 connection pool: -->
 		<!-- https://www.mchange.com/projects/c3p0/#configuration_properties -->
 		<property name="hibernate.connection.provider_class">org.hibernate.connection.C3P0ConnectionProvider</property>
-		<property name="hibernate.c3p0.min_size">2</property>
-		<property name="hibernate.c3p0.initialPoolSize">2</property>
-		<property name="hibernate.c3p0.max_size">8</property>
+		<property name="hibernate.c3p0.min_size">4</property>
+		<property name="hibernate.c3p0.initialPoolSize">4</property>
+		<property name="hibernate.c3p0.max_size">12</property>
 		<property name="hibernate.c3p0.acquire_increment">3</property>
 		<property name="hibernate.c3p0.autoCommitOnClose">false</property>
 
 		<property name="hibernate.c3p0.timeout">3600</property>                   <!-- seconds -->
-		<property name="hibernate.c3p0.idle_test_period">0</property>             <!-- seconds -->
-		<property name="hibernate.c3p0.maxIdleTime">0</property>                  <!-- seconds -->
-		<property name="hibernate.c3p0.checkoutTimeout">60000</property>          <!-- milliseconds -->
+		<property name="hibernate.c3p0.idle_test_period">3600</property>          <!-- seconds -->
+		<property name="hibernate.c3p0.checkoutTimeout">600000</property>         <!-- milliseconds -->
 		<property name="hibernate.c3p0.maxAdministrativeTaskTime">900</property>  <!-- seconds -->
+		<property name="hibernate.c3p0.maxIdleTime">0</property>                  <!-- seconds -->
+		<property name="hibernate.c3p0.unreturnedConnectionTimeout">0</property>  <!-- seconds -->
+		<property name="hibernate.c3p0.debugUnreturnedConnectionStackTraces">false</property>
 
+		<!-- Turn off C3P0 statement caching: -->
 		<property name="hibernate.c3p0.max_statements">0</property>
 		<property name="hibernate.c3p0.maxStatementsPerConnection">0</property>
 
-		<property name="hibernate.c3p0.unreturnedConnectionTimeout">0</property>  <!-- seconds -->
-		<property name="hibernate.c3p0.debugUnreturnedConnectionStackTraces">true</property>
-
-		<property name="hibernate.c3p0.testConnectionOnCheckout">true</property>
+		<property name="hibernate.c3p0.testConnectionOnCheckout">false</property>
 		<property name="hibernate.c3p0.connectionTesterClassName">gov.ca.cwds.neutron.quark.NeutronNoOpConnectionTester</property>
 		<property name="hibernate.c3p0.preferredTestQuery">SELECT 1 FROM SYSIBM.SYSDUMMY1 FOR READ ONLY WITH UR</property>
+
+		<!-- DB2 OPTIONS: -->
+		<!-- Multi-row fetch: -->
+		<!-- <property name="hibernate.connection.enableRowsetSupport">1</property> -->
+
+		<!-- Result set safety: avoid ERRORCODE=-1224, SQLSTATE=55032-->
+		<property name="hibernate.connection.allowNextOnExhaustedResultSet">1</property>
 
 	</session-factory>
 

--- a/src/main/resources/jobs-cms-hibernate.cfg.xml
+++ b/src/main/resources/jobs-cms-hibernate.cfg.xml
@@ -28,7 +28,7 @@
 
 		<property name="hibernate.connection.connectionTimeout">1000000</property>
 		<property name="hibernate.connection.loginTimeout">1000000</property>
-		<property name="hibernate.connection.keepAliveTimeOut">60000</property>     <!-- seconds -->
+		<property name="hibernate.connection.keepAliveTimeOut">60000</property>     <!-- seconds? -->
 		
 		<property name="hibernate.connection.enableRowsetSupport">1</property>
 		<property name="hibernate.connection.autocommit">false</property>
@@ -49,7 +49,7 @@
 		<property name="hibernate.c3p0.acquire_increment">3</property>
 		<property name="hibernate.c3p0.autoCommitOnClose">false</property>
 
-		<property name="hibernate.c3p0.timeout">1800</property>                   <!-- seconds -->
+		<property name="hibernate.c3p0.timeout">3600</property>                   <!-- seconds -->
 		<property name="hibernate.c3p0.idle_test_period">0</property>             <!-- seconds -->
 		<property name="hibernate.c3p0.maxIdleTime">0</property>                  <!-- seconds -->
 		<property name="hibernate.c3p0.checkoutTimeout">60000</property>          <!-- milliseconds -->

--- a/src/main/resources/jobs-cms-hibernate.cfg.xml
+++ b/src/main/resources/jobs-cms-hibernate.cfg.xml
@@ -28,7 +28,7 @@
 
 		<property name="hibernate.connection.connectionTimeout">1000000</property>
 		<property name="hibernate.connection.loginTimeout">1000000</property>
-		<property name="hibernate.connection.keepAliveTimeOut">3600</property>     <!-- seconds -->
+		<property name="hibernate.connection.keepAliveTimeOut">3600</property>        <!-- seconds -->
 
 		<!-- Turn off Hibernate caching: -->
 		<property name="hibernate.connection.autocommit">false</property>
@@ -49,12 +49,12 @@
 		<property name="hibernate.c3p0.acquire_increment">2</property>
 		<property name="hibernate.c3p0.autoCommitOnClose">false</property>
 
-		<property name="hibernate.c3p0.timeout">3600</property>                   <!-- seconds -->
-		<property name="hibernate.c3p0.idle_test_period">3600</property>          <!-- seconds -->
-		<property name="hibernate.c3p0.checkoutTimeout">600000</property>         <!-- milliseconds -->
-		<property name="hibernate.c3p0.maxAdministrativeTaskTime">900</property>  <!-- seconds -->
-		<property name="hibernate.c3p0.maxIdleTime">0</property>                  <!-- seconds -->
-		<property name="hibernate.c3p0.unreturnedConnectionTimeout">0</property>  <!-- seconds -->
+		<property name="hibernate.c3p0.timeout">3600</property>                      <!-- seconds -->
+		<property name="hibernate.c3p0.idle_test_period">3600</property>             <!-- seconds -->
+		<property name="hibernate.c3p0.checkoutTimeout">600000</property>            <!-- milliseconds -->
+		<property name="hibernate.c3p0.maxAdministrativeTaskTime">900</property>     <!-- seconds -->
+		<property name="hibernate.c3p0.maxIdleTime">0</property>                     <!-- seconds -->
+		<property name="hibernate.c3p0.unreturnedConnectionTimeout">0</property>     <!-- seconds -->
 		<property name="hibernate.c3p0.debugUnreturnedConnectionStackTraces">false</property>
 
 		<!-- Turn off C3P0 statement caching: -->
@@ -64,6 +64,10 @@
 		<property name="hibernate.c3p0.testConnectionOnCheckout">false</property>
 		<property name="hibernate.c3p0.connectionTesterClassName">gov.ca.cwds.neutron.quark.NeutronNoOpConnectionTester</property>
 		<property name="hibernate.c3p0.preferredTestQuery">SELECT 1 FROM SYSIBM.SYSDUMMY1 FOR READ ONLY WITH UR</property>
+
+		<!-- C3P0 DEBUGGING: -->
+		<property name="hibernate.c3p0.unreturnedConnectionTimeout">3600</property>  <!-- seconds -->
+		<property name="hibernate.c3p0.debugUnreturnedConnectionStackTraces">true</property>
 
 		<!-- DB2 OPTIONS: -->
 		<!-- Multi-row fetch: -->

--- a/src/main/resources/jobs-cms-hibernate.cfg.xml
+++ b/src/main/resources/jobs-cms-hibernate.cfg.xml
@@ -46,7 +46,7 @@
 		<property name="hibernate.c3p0.min_size">4</property>
 		<property name="hibernate.c3p0.initialPoolSize">4</property>
 		<property name="hibernate.c3p0.max_size">12</property>
-		<property name="hibernate.c3p0.acquire_increment">3</property>
+		<property name="hibernate.c3p0.acquire_increment">2</property>
 		<property name="hibernate.c3p0.autoCommitOnClose">false</property>
 
 		<property name="hibernate.c3p0.timeout">3600</property>                   <!-- seconds -->

--- a/src/main/resources/jobs-cms-hibernate.cfg.xml
+++ b/src/main/resources/jobs-cms-hibernate.cfg.xml
@@ -73,7 +73,7 @@
 		<!-- Multi-row fetch: -->
 		<!-- <property name="hibernate.connection.enableRowsetSupport">1</property> -->
 
-		<!-- Result set safety: avoid ERRORCODE=-1224, SQLSTATE=55032-->
+		<!-- Result set safety: avoid ERRORCODE=-1224, SQLSTATE=55032 -->
 		<property name="hibernate.connection.allowNextOnExhaustedResultSet">1</property>
 
 	</session-factory>

--- a/src/test/java/gov/ca/cwds/data/persistence/cms/EsPersonReferralTest.java
+++ b/src/test/java/gov/ca/cwds/data/persistence/cms/EsPersonReferralTest.java
@@ -477,14 +477,10 @@ public class EsPersonReferralTest extends Goddard<ReplicatedPersonReferrals, EsP
     assertThat(actual, is(notNullValue()));
   }
 
-  @Test
+  @Test(expected = SQLException.class)
   public void extractAllegation_Args__ResultSet_T__SQLException() throws Exception {
-    try {
-      doThrow(new SQLException()).when(rs).getString(any());
-      EsPersonReferral.extractAllegation(rs);
-      fail("Expected exception was not thrown!");
-    } catch (SQLException e) {
-    }
+    doThrow(new SQLException()).when(rs).getString(any());
+    EsPersonReferral.extractAllegation(rs);
   }
 
   @Test
@@ -493,14 +489,10 @@ public class EsPersonReferralTest extends Goddard<ReplicatedPersonReferrals, EsP
     assertThat(actual, is(notNullValue()));
   }
 
-  @Test
+  @Test(expected = SQLException.class)
   public void extractReferral_Args__ResultSet_T__SQLException() throws Exception {
-    try {
-      doThrow(new SQLException()).when(rs).getString(any());
-      EsPersonReferral.extractReferral(rs);
-      fail("Expected exception was not thrown!");
-    } catch (SQLException e) {
-    }
+    doThrow(new SQLException()).when(rs).getString(any());
+    EsPersonReferral.extractReferral(rs);
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/jobs/ClientIndexerJobTest.java
+++ b/src/test/java/gov/ca/cwds/jobs/ClientIndexerJobTest.java
@@ -207,7 +207,7 @@ public class ClientIndexerJobTest extends Goddard<ReplicatedClient, EsClientAddr
 
   @Test
   public void iterateRangeResults_Args__ResultSet() throws Exception {
-    target.handleMainResults(rs);
+    target.handleMainResults(rs, null);
   }
 
   @Test
@@ -268,12 +268,12 @@ public class ClientIndexerJobTest extends Goddard<ReplicatedClient, EsClientAddr
 
   @Test
   public void handleRangeResults_Args__ResultSet() throws Exception {
-    target.handleMainResults(rs);
+    target.handleMainResults(rs, null);
   }
 
   @Test
   public void handleRangeResults_Args__ResultSet__2() throws Exception {
-    target.handleMainResults(rs);
+    target.handleMainResults(rs, null);
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/jobs/ClientPersonIndexerJobTest.java
+++ b/src/test/java/gov/ca/cwds/jobs/ClientPersonIndexerJobTest.java
@@ -133,7 +133,7 @@ public class ClientPersonIndexerJobTest extends Goddard<ReplicatedClient, EsClie
 
   @Test
   public void initialLoadProcessRangeResults_A$ResultSet() throws Exception {
-    target.handleMainResults(rs, null);
+    target.handleMainResults(rs, con);
   }
 
   @Test(expected = SQLException.class)

--- a/src/test/java/gov/ca/cwds/jobs/ClientPersonIndexerJobTest.java
+++ b/src/test/java/gov/ca/cwds/jobs/ClientPersonIndexerJobTest.java
@@ -133,13 +133,13 @@ public class ClientPersonIndexerJobTest extends Goddard<ReplicatedClient, EsClie
 
   @Test
   public void initialLoadProcessRangeResults_A$ResultSet() throws Exception {
-    target.handleMainResults(rs);
+    target.handleMainResults(rs, null);
   }
 
   @Test(expected = SQLException.class)
   public void initialLoadProcessRangeResults_A$ResultSet_T$SQLException() throws Exception {
     when(rs.next()).thenThrow(SQLException.class);
-    target.handleMainResults(rs);
+    target.handleMainResults(rs, null);
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/jobs/ClientSummaryIndexerJobTest.java
+++ b/src/test/java/gov/ca/cwds/jobs/ClientSummaryIndexerJobTest.java
@@ -170,7 +170,7 @@ public class ClientSummaryIndexerJobTest extends Goddard<ReplicatedClient, EsCli
   public void getPartitionRanges_RSQ() throws Exception {
     System.setProperty("DB_CMS_SCHEMA", "CWSRSQ");
     final List<Pair<String, String>> actual = target.getPartitionRanges();
-    assertThat(actual.size(), is(equalTo(511)));
+    assertThat(actual.size(), is(equalTo(1025)));
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/jobs/ClientSummaryIndexerJobTest.java
+++ b/src/test/java/gov/ca/cwds/jobs/ClientSummaryIndexerJobTest.java
@@ -209,7 +209,7 @@ public class ClientSummaryIndexerJobTest extends Goddard<ReplicatedClient, EsCli
 
   @Test
   public void iterateRangeResults_Args__ResultSet() throws Exception {
-    target.handleMainResults(rs, null);
+    target.handleMainResults(rs, con);
   }
 
   @Test
@@ -270,12 +270,12 @@ public class ClientSummaryIndexerJobTest extends Goddard<ReplicatedClient, EsCli
 
   @Test
   public void handleRangeResults_Args__ResultSet() throws Exception {
-    target.handleMainResults(rs, null);
+    target.handleMainResults(rs, con);
   }
 
   @Test
   public void handleRangeResults_Args__ResultSet__2() throws Exception {
-    target.handleMainResults(rs, null);
+    target.handleMainResults(rs, con);
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/jobs/ClientSummaryIndexerJobTest.java
+++ b/src/test/java/gov/ca/cwds/jobs/ClientSummaryIndexerJobTest.java
@@ -209,7 +209,7 @@ public class ClientSummaryIndexerJobTest extends Goddard<ReplicatedClient, EsCli
 
   @Test
   public void iterateRangeResults_Args__ResultSet() throws Exception {
-    target.handleMainResults(rs);
+    target.handleMainResults(rs, null);
   }
 
   @Test
@@ -270,12 +270,12 @@ public class ClientSummaryIndexerJobTest extends Goddard<ReplicatedClient, EsCli
 
   @Test
   public void handleRangeResults_Args__ResultSet() throws Exception {
-    target.handleMainResults(rs);
+    target.handleMainResults(rs, null);
   }
 
   @Test
   public void handleRangeResults_Args__ResultSet__2() throws Exception {
-    target.handleMainResults(rs);
+    target.handleMainResults(rs, null);
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/jobs/ReferralHistoryIndexerJobTest.java
+++ b/src/test/java/gov/ca/cwds/jobs/ReferralHistoryIndexerJobTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import gov.ca.cwds.neutron.atom.AtomLaunchDirector;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -35,6 +34,7 @@ import gov.ca.cwds.data.es.ElasticSearchPersonReferral;
 import gov.ca.cwds.data.es.ElasticsearchDao;
 import gov.ca.cwds.data.persistence.cms.EsPersonReferral;
 import gov.ca.cwds.data.persistence.cms.ReplicatedPersonReferrals;
+import gov.ca.cwds.neutron.atom.AtomLaunchDirector;
 import gov.ca.cwds.neutron.exception.NeutronCheckedException;
 import gov.ca.cwds.neutron.exception.NeutronRuntimeException;
 import gov.ca.cwds.neutron.flight.FlightPlan;
@@ -515,7 +515,7 @@ public class ReferralHistoryIndexerJobTest
 
   @Test(expected = SQLException.class)
   public void getConnection_Args___T__SQLException() throws Exception {
-    when(cp.getConnection()).thenThrow(SQLException.class);
+    when(dao.grabSession()).thenThrow(SQLException.class);
     target.getConnection();
   }
 

--- a/src/test/java/gov/ca/cwds/neutron/atom/AtomInitialLoadTest.java
+++ b/src/test/java/gov/ca/cwds/neutron/atom/AtomInitialLoadTest.java
@@ -104,7 +104,7 @@ public class AtomInitialLoadTest extends Goddard<TestDenormalizedEntity, TestDen
 
   @Test
   public void handleRangeResults_Args__ResultSet() throws Exception {
-    target.handleMainResults(rs);
+    target.handleMainResults(rs, null);
   }
 
   @Test
@@ -140,7 +140,7 @@ public class AtomInitialLoadTest extends Goddard<TestDenormalizedEntity, TestDen
 
   @Test
   public void initialLoadProcessRangeResults_Args__ResultSet() throws Exception {
-    target.handleMainResults(rs);
+    target.handleMainResults(rs, null);
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandlerTest.java
+++ b/src/test/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandlerTest.java
@@ -171,7 +171,7 @@ public class PeopleSummaryThreadHandlerTest extends Goddard<ReplicatedClient, Es
   @Test
   public void prepAffectedClients_A$PreparedStatement$Pair() throws Exception {
     Pair<String, String> p = pair;
-    target.prepAffectedClients(preparedStatement, p);
+    target.prepPlacementClients(preparedStatement, p);
   }
 
   @Test(expected = SQLException.class)
@@ -180,7 +180,7 @@ public class PeopleSummaryThreadHandlerTest extends Goddard<ReplicatedClient, Es
     when(preparedStatement.executeUpdate()).thenThrow(SQLException.class);
 
     Pair<String, String> p = pair;
-    target.prepAffectedClients(preparedStatement, p);
+    target.prepPlacementClients(preparedStatement, p);
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandlerTest.java
+++ b/src/test/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandlerTest.java
@@ -64,13 +64,13 @@ public class PeopleSummaryThreadHandlerTest extends Goddard<ReplicatedClient, Es
 
   @Test
   public void handleMainResults_A$ResultSet() throws Exception {
-    target.handleMainResults(rs);
+    target.handleMainResults(rs, null);
   }
 
   @Test(expected = SQLException.class)
   public void handleMainResults_A$ResultSet_T$SQLException() throws Exception {
     when(rs.getString(any(String.class))).thenThrow(SQLException.class);
-    target.handleMainResults(rs);
+    target.handleMainResults(rs, null);
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandlerTest.java
+++ b/src/test/java/gov/ca/cwds/neutron/rocket/PeopleSummaryThreadHandlerTest.java
@@ -5,10 +5,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -64,13 +64,13 @@ public class PeopleSummaryThreadHandlerTest extends Goddard<ReplicatedClient, Es
 
   @Test
   public void handleMainResults_A$ResultSet() throws Exception {
-    target.handleMainResults(rs, null);
+    target.handleMainResults(rs, con);
   }
 
   @Test(expected = SQLException.class)
   public void handleMainResults_A$ResultSet_T$SQLException() throws Exception {
     when(rs.getString(any(String.class))).thenThrow(SQLException.class);
-    target.handleMainResults(rs, null);
+    target.handleMainResults(rs, con);
   }
 
   @Test
@@ -81,9 +81,9 @@ public class PeopleSummaryThreadHandlerTest extends Goddard<ReplicatedClient, Es
 
   @Test(expected = NeutronRuntimeException.class)
   public void handleSecondaryJdbc_A$Connection$Pair_T$SQLException() throws Exception {
-    Connection con = mock(Connection.class);
-    Pair<String, String> range = pair;
-    target.handleSecondaryJdbc(con, range);
+    doThrow(new SQLException()).when(con).commit();
+    doThrow(new SQLException()).when(rs).getString(any());
+    target.handleSecondaryJdbc(con, pair);
   }
 
   @Test


### PR DESCRIPTION
SNAP-715: Staging Initial Load: ERRORCODE=-1224, SQLSTATE=55032

https://osi-cwds.atlassian.net/browse/SNAP-715

Smaller client range buckets leads to:

* Shorter transactions
* More commits (free DB2 resources)
* Less database pressure
* Fewer DB2 errors overall

To that end, I am implementing the following changes in Neutron:

* Double client range buckets from 512 to 1024.
  * Commit (cleanup database resources) more frequently.
  * Pulls half as many client records per bucket to avoid errors on ResultSet.next().
* Retrieve denormalized MQT records first, then normalize.
  * Takes more heap memory but reduces database errors.
  * Original code normalized while retrieving to reduce Java memory footprint.
* Turn off DB2 multi-row fetch.
  * Multi-row fetch allows for faster retrieval but may have contributed to JDBC driver instability.
  * Can experiment with this feature another time.
* Increase client connection timeouts to 1 hour.
  * Timeouts were previously too short and trip when the database is busy.
* Enable DB2 "allowNextOnExhaustedResultSet"
  * Hopefully avoids "ERRORCODE=-1224, SQLSTATE=55032" when closing cursors.
  * Don't fail the whole run if a result set fails to close.
  * Log a warning and continue processing.
  * If the parent statement or session/connection fails to commit or close, then fail as usual.
