### PR TITLE
Check connection status on get connection

### DIFF
--- a/src/main/resources/jobs-cms-hibernate.cfg.xml
+++ b/src/main/resources/jobs-cms-hibernate.cfg.xml
@@ -61,8 +61,8 @@
 		<property name="hibernate.c3p0.max_statements">0</property>
 		<property name="hibernate.c3p0.maxStatementsPerConnection">0</property>
 
-		<property name="hibernate.c3p0.testConnectionOnCheckout">false</property>
-		<property name="hibernate.c3p0.connectionTesterClassName">gov.ca.cwds.neutron.quark.NeutronNoOpConnectionTester</property>
+		<property name="hibernate.c3p0.testConnectionOnCheckout">true</property>
+		<!-- <property name="hibernate.c3p0.connectionTesterClassName">gov.ca.cwds.neutron.quark.NeutronNoOpConnectionTester</property> -->
 		<property name="hibernate.c3p0.preferredTestQuery">SELECT 1 FROM SYSIBM.SYSDUMMY1 FOR READ ONLY WITH UR</property>
 
 		<!-- C3P0 DEBUGGING: -->


### PR DESCRIPTION
When pulling a connection from the C3P0 connection pool, verify the connection status before attempting queries.

Configuration change only.