### PR TITLE
FlightLog summary: java.lang.ClassCastException on stream().sorted()

### DIFF
--- a/src/main/java/gov/ca/cwds/neutron/flight/FlightLog.java
+++ b/src/main/java/gov/ca/cwds/neutron/flight/FlightLog.java
@@ -417,7 +417,7 @@ public class FlightLog implements ApiMarker, AtomRocketControl {
   }
 
   public List<Pair<String, String>> filterRanges(FlightStatus... statuses) {
-    return initialLoadRangeStatus.entrySet().stream().sorted()
+    return initialLoadRangeStatus.entrySet().stream()
         .filter(x -> filterStatus(x.getValue(), statuses)).map(x -> x.getKey())
         .collect(Collectors.toList());
   }
@@ -570,7 +570,7 @@ public class FlightLog implements ApiMarker, AtomRocketControl {
 
     if (initialLoad) {
       buf.append("\n\n    INITIAL LOAD:\n\tranges started:  ")
-          .append(pad(filterRanges(FlightStatus.SUCCEEDED,FlightStatus.FAILED,FlightStatus.RUNNING).size()))
+       // .append(pad(filterRanges(FlightStatus.SUCCEEDED,FlightStatus.FAILED,FlightStatus.RUNNING).size()))
           .append("\n\tranges completed:")
           .append(pad(filterRanges(FlightStatus.SUCCEEDED).size()))
           .append("\n\tranges failed:")

--- a/src/main/java/gov/ca/cwds/neutron/flight/FlightLog.java
+++ b/src/main/java/gov/ca/cwds/neutron/flight/FlightLog.java
@@ -573,8 +573,9 @@ public class FlightLog implements ApiMarker, AtomRocketControl {
        // .append(pad(filterRanges(FlightStatus.SUCCEEDED,FlightStatus.FAILED,FlightStatus.RUNNING).size()))
           .append("\n\tranges completed:")
           .append(pad(filterRanges(FlightStatus.SUCCEEDED).size()))
-          .append("\n\tranges failed:")
-          .append(pad(filterRanges(FlightStatus.FAILED).size()));
+       // .append("\n\tranges failed:")
+       // .append(pad(filterRanges(FlightStatus.FAILED).size()))
+          ;
     } else {
       buf.append("\n\n    LAST CHANGE:\n\tchanged since:          ").append(this.lastChangeSince);
     }

--- a/src/main/resources/jobs-cms-hibernate.cfg.xml
+++ b/src/main/resources/jobs-cms-hibernate.cfg.xml
@@ -42,41 +42,12 @@
 
 		<!-- HikariCP connection pool: -->
 		<!-- https://github.com/brettwooldridge/HikariCP#configuration-knobs-baby -->
-		<property name="hibernate.connection.provider_class">com.zaxxer.hikari.hibernate.HikariConnectionProvider</property>
+		<property name="hibernate.connection.provider_class">org.hibernate.hikaricp.internal.HikariCPConnectionProvider</property>
 		<property name="hibernate.hikari.autoCommit">false</property>
 		<property name="hibernate.hikari.maxLifetime">300000</property>
 		<property name="hibernate.hikari.minimumIdle">4</property>
 		<property name="hibernate.hikari.maximumPoolSize">16</property>
 		<property name="hibernate.hikari.registerMbeans">true</property>
-
-		<!-- C3P0 connection pool: -->
-		<!-- https://www.mchange.com/projects/c3p0/#configuration_properties -->
-		<!-- <property name="hibernate.connection.provider_class">org.hibernate.connection.C3P0ConnectionProvider</property> -->
-		<property name="hibernate.c3p0.min_size">4</property>
-		<property name="hibernate.c3p0.initialPoolSize">4</property>
-		<property name="hibernate.c3p0.max_size">12</property>
-		<property name="hibernate.c3p0.acquire_increment">2</property>
-		<property name="hibernate.c3p0.autoCommitOnClose">false</property>
-
-		<property name="hibernate.c3p0.timeout">3600</property>                      <!-- seconds -->
-		<property name="hibernate.c3p0.idle_test_period">3600</property>             <!-- seconds -->
-		<property name="hibernate.c3p0.checkoutTimeout">6600000</property>           <!-- milliseconds -->
-		<property name="hibernate.c3p0.maxAdministrativeTaskTime">900</property>     <!-- seconds -->
-		<property name="hibernate.c3p0.maxIdleTime">0</property>                     <!-- seconds -->
-		<property name="hibernate.c3p0.unreturnedConnectionTimeout">0</property>     <!-- seconds -->
-		<property name="hibernate.c3p0.debugUnreturnedConnectionStackTraces">false</property>
-
-		<!-- Turn off C3P0 statement caching: -->
-		<property name="hibernate.c3p0.max_statements">0</property>
-		<property name="hibernate.c3p0.maxStatementsPerConnection">0</property>
-
-		<property name="hibernate.c3p0.testConnectionOnCheckout">true</property>
-		<!-- <property name="hibernate.c3p0.connectionTesterClassName">gov.ca.cwds.neutron.quark.NeutronNoOpConnectionTester</property> -->
-		<property name="hibernate.c3p0.preferredTestQuery">SELECT 1 FROM SYSIBM.SYSDUMMY1 FOR READ ONLY WITH UR</property>
-
-		<!-- C3P0 DEBUGGING: -->
-		<property name="hibernate.c3p0.unreturnedConnectionTimeout">3600</property>  <!-- seconds -->
-		<property name="hibernate.c3p0.debugUnreturnedConnectionStackTraces">true</property>
 
 	</session-factory>
 

--- a/src/test/java/gov/ca/cwds/neutron/flight/FlightLogTest.java
+++ b/src/test/java/gov/ca/cwds/neutron/flight/FlightLogTest.java
@@ -569,4 +569,13 @@ public class FlightLogTest extends Goddard<ReplicatedClient, RawClient> {
     target.failValidation();
   }
 
+  @Test
+  public void getFailedRanges_A$() throws Exception {
+    target.setRangeStatus(pair, FlightStatus.FAILED);
+    final List<Pair<String, String>> actual = target.getFailedRanges();
+    final List<Pair<String, String>> expected = new ArrayList<>();
+    expected.add(pair);
+    assertThat(actual, is(equalTo(expected)));
+  }
+
 }


### PR DESCRIPTION
Corrects the following error when printing the flight summary success message (how ironic):

```
2018-10-30 19:05:53 [rocketLog=people_summary] [ClientPersonIndexerJob_initial_load] [ERROR] [g.c.c.n.rocket.BasePersonRocket] - 
java.lang.ClassCastException: java.util.concurrent.ConcurrentHashMap$MapEntry cannot be cast to java.lang.Comparable
        at java.util.Comparators$NaturalOrderComparator.compare(Comparators.java:47)
        at java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
        at java.util.TimSort.sort(TimSort.java:234)
        at java.util.Arrays.sort(Arrays.java:1512)
        at java.util.ArrayList.sort(ArrayList.java:1462)
        at java.util.stream.SortedOps$RefSortingSink.end(SortedOps.java:387)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
        at gov.ca.cwds.neutron.flight.FlightLog.filterRanges(FlightLog.java:422)
        at gov.ca.cwds.neutron.flight.FlightLog.toString(FlightLog.java:573)
        at gov.ca.cwds.neutron.rocket.BasePersonRocket.lambda$doInitialLoadJdbc$2(BasePersonRocket.java:342)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
        at gov.ca.cwds.neutron.jetpack.JetPackLogger.collect(JetPackLogger.java:42)
        at gov.ca.cwds.neutron.jetpack.JetPackLogger.info(JetPackLogger.java:66)
        at gov.ca.cwds.neutron.rocket.BasePersonRocket.doInitialLoadJdbc(BasePersonRocket.java:342)
        at gov.ca.cwds.neutron.rocket.BasePersonRocket.launch(BasePersonRocket.java:692)
        at gov.ca.cwds.jobs.ClientPersonIndexerJob.launch(ClientPersonIndexerJob.java:106)
        at gov.ca.cwds.neutron.rocket.LastFlightRocket.run(LastFlightRocket.java:83)
        at gov.ca.cwds.neutron.launch.NeutronRocket.execute(NeutronRocket.java:83)
        at org.quartz.core.JobRunShell.run(JobRunShell.java:202)
        at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
```