### PR TITLE
Dave SNAP-800

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'jacoco'
 
 project.ext {
-    coreApiVersion = "1.10.3_893-RC"
+    coreApiVersion = "1.10.3_895-RC"
     log4jVersion = "2.8"
     elasticsearchVersion = "5.5.0"
     personIndexerJob = "gov.ca.cwds.jobs.PersonIndexerJob"

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/client/RawClient.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/client/RawClient.java
@@ -344,8 +344,8 @@ public class RawClient extends ClientReference implements NeutronJdbcReader<RawC
     this.cltPrevCaChildrenServIndicator = ifNull(rs.getString("CLT_PREVCA_IND"));
     this.cltPrevOtherDescription = ifNull(rs.getString("CLT_POTH_DESC"));
     this.cltPrevRegionalCenterIndicator = ifNull(rs.getString("CLT_PREREG_IND"));
-    this.cltPrimaryEthnicityType = rs.getShort("CLT_P_ETHNCTYC");
 
+    this.cltPrimaryEthnicityType = rs.getShort("CLT_P_ETHNCTYC");
     this.cltPrimaryLanguageType = rs.getShort("CLT_P_LANG_TPC");
     this.cltSecondaryLanguageType = rs.getShort("CLT_S_LANG_TC");
 

--- a/src/main/java/gov/ca/cwds/jobs/schedule/LaunchCommand.java
+++ b/src/main/java/gov/ca/cwds/jobs/schedule/LaunchCommand.java
@@ -108,7 +108,7 @@ public class LaunchCommand implements AutoCloseable, AtomLaunchCommand {
    */
   protected void resetTimestamps(boolean initialMode, int hoursInPast) throws IOException {
     final DateFormat fmt =
-        new SimpleDateFormat(NeutronDateTimeFormat.LAST_RUN_DATE_FORMAT.getFormat());
+        new SimpleDateFormat(NeutronDateTimeFormat.FMT_LAST_RUN_DATE.getFormat());
     final Date now = new DateTime().minusHours(initialMode ? 876000 : hoursInPast).toDate();
 
     // OPTION: soft-code rockets to launch.
@@ -222,7 +222,7 @@ public class LaunchCommand implements AutoCloseable, AtomLaunchCommand {
     try {
       // NOTE: make last change window configurable.
       final DateFormat fmt =
-          new SimpleDateFormat(NeutronDateTimeFormat.LAST_RUN_DATE_FORMAT.getFormat());
+          new SimpleDateFormat(NeutronDateTimeFormat.FMT_LAST_RUN_DATE.getFormat());
       final Date now = settings.isInitialMode() ? fmt.parse("1917-10-31 10:11:12.000")
           : new DateTime().minusHours(NeutronSchedulerConstants.LAST_CHG_WINDOW_HOURS).toDate();
 

--- a/src/main/java/gov/ca/cwds/neutron/atom/AtomFlightRecorder.java
+++ b/src/main/java/gov/ca/cwds/neutron/atom/AtomFlightRecorder.java
@@ -11,7 +11,7 @@ import gov.ca.cwds.neutron.flight.FlightSummary;
 import gov.ca.cwds.neutron.launch.StandardFlightSchedule;
 
 /**
- * Flight Recorder interface.
+ * Flight Recorder interface. A flight recorder records flights details across flights.
  * 
  * @author CWDS API Team
  */

--- a/src/main/java/gov/ca/cwds/neutron/enums/NeutronDateTimeFormat.java
+++ b/src/main/java/gov/ca/cwds/neutron/enums/NeutronDateTimeFormat.java
@@ -8,17 +8,17 @@ public enum NeutronDateTimeFormat {
   /**
    * Date time format for last run date file.
    */
-  LAST_RUN_DATE_FORMAT("yyyy-MM-dd HH:mm:ss"),
+  FMT_LAST_RUN_DATE("yyyy-MM-dd HH:mm:ss"),
 
   /**
-   * Date format for legacy DB2.
+   * Date format for legacy DB2 on z/OS (mainframe).
    */
-  LEGACY_DATE_FORMAT("yyyy-MM-dd"),
+  FMT_LEGACY_DATE("yyyy-MM-dd"),
 
   /**
-   * Timestamp format for legacy DB2.
+   * Timestamp format for legacy DB2 on z/OS (mainframe).
    */
-  LEGACY_TIMESTAMP_FORMAT("yyyy-MM-dd HH:mm:ss.SSS");
+  FMT_LEGACY_TIMESTAMP("yyyy-MM-dd HH:mm:ss.SSS");
 
   private final String format;
 

--- a/src/main/java/gov/ca/cwds/neutron/flight/FlightLog.java
+++ b/src/main/java/gov/ca/cwds/neutron/flight/FlightLog.java
@@ -64,7 +64,7 @@ public class FlightLog implements ApiMarker, AtomRocketControl {
   /**
    * Completion flag for fatal errors.
    * <p>
-   * Volatile guarantees that changes to this flag become visible other threads immediately. In
+   * Volatile guarantees that changes to this flag are immediately made visible to other threads. In
    * other words, threads don't cache a copy of this variable in their local memory for performance.
    * </p>
    */
@@ -170,6 +170,8 @@ public class FlightLog implements ApiMarker, AtomRocketControl {
    */
   private final Queue<String> affectedDocumentIds = new CircularFifoQueue<>();
 
+  private String failureCause;
+
   // =======================
   // CONSTRUCTORS:
   // =======================
@@ -235,6 +237,13 @@ public class FlightLog implements ApiMarker, AtomRocketControl {
       this.status = FlightStatus.RUNNING;
       startTime = System.currentTimeMillis();
     }
+  }
+
+  public void fail(String reason) {
+    if (StringUtils.isBlank(failureCause) && StringUtils.isNotBlank(reason)) {
+      setFailureCause(reason);
+    }
+    fail();
   }
 
   @Override
@@ -674,6 +683,14 @@ public class FlightLog implements ApiMarker, AtomRocketControl {
 
   public void setStartTime(long startTime) {
     this.startTime = startTime;
+  }
+
+  public String getFailureCause() {
+    return failureCause;
+  }
+
+  public void setFailureCause(String failureCause) {
+    this.failureCause = failureCause;
   }
 
 }

--- a/src/main/java/gov/ca/cwds/neutron/flight/FlightSummary.java
+++ b/src/main/java/gov/ca/cwds/neutron/flight/FlightSummary.java
@@ -1,5 +1,7 @@
 package gov.ca.cwds.neutron.flight;
 
+import static gov.ca.cwds.neutron.util.shrinkray.NeutronDateUtils.freshDate;
+
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.Map;
@@ -13,7 +15,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import gov.ca.cwds.data.std.ApiMarker;
 import gov.ca.cwds.neutron.enums.FlightStatus;
 import gov.ca.cwds.neutron.launch.StandardFlightSchedule;
-import gov.ca.cwds.neutron.util.shrinkray.NeutronDateUtils;
 import gov.ca.cwds.rest.api.domain.DomainChef;
 import gov.ca.cwds.utils.JsonUtils;
 
@@ -226,20 +227,20 @@ public class FlightSummary implements ApiMarker {
 
   @JsonIgnore
   public Date getFirstStart() {
-    return NeutronDateUtils.freshDate(firstStart);
+    return freshDate(firstStart);
   }
 
   public void setFirstStart(Date firstStart) {
-    this.firstStart = NeutronDateUtils.freshDate(firstStart);
+    this.firstStart = freshDate(firstStart);
   }
 
   @JsonIgnore
   public Date getLastEnd() {
-    return NeutronDateUtils.freshDate(lastEnd);
+    return freshDate(lastEnd);
   }
 
   public void setLastEnd(Date lastEnd) {
-    this.lastEnd = NeutronDateUtils.freshDate(lastEnd);
+    this.lastEnd = freshDate(lastEnd);
   }
 
   @Override

--- a/src/main/java/gov/ca/cwds/neutron/launch/LaunchPad.java
+++ b/src/main/java/gov/ca/cwds/neutron/launch/LaunchPad.java
@@ -202,10 +202,11 @@ public class LaunchPad implements VoxLaunchPadMBean, AtomLaunchPad {
   @Managed(description = "Unschedule rocket")
   public void unschedule() throws NeutronCheckedException {
     try {
-      LOGGER.warn("UNSCHEDULE LAUNCH! {}", rocketName);
+      LOGGER.warn("UNSCHEDULE ROCKET LAUNCH! {}", rocketName);
       scheduler.unscheduleJob(triggerKey);
     } catch (Exception e) {
-      throw CheeseRay.checked(LOGGER, e, "FAILED UNSCHEDULED LAUNCH! rocket: {}", rocketName);
+      throw CheeseRay.checked(LOGGER, e, "FAILED TO UNSCHEDULE ROCKET LAUNCH! rocket: {}",
+          rocketName);
     }
   }
 
@@ -213,7 +214,7 @@ public class LaunchPad implements VoxLaunchPadMBean, AtomLaunchPad {
   // STATUS/HISTORY/LOG:
   // =======================
 
-  @Managed(description = "Show rocket flight statistics across flights")
+  @Managed(description = "Show flight statistics across flights for this rocket")
   @Override
   public String summary() {
     try {
@@ -275,7 +276,7 @@ public class LaunchPad implements VoxLaunchPadMBean, AtomLaunchPad {
 
   protected void resetTimestamp(boolean initialMode, int hoursInPast) throws IOException {
     final DateFormat fmt =
-        new SimpleDateFormat(NeutronDateTimeFormat.LAST_RUN_DATE_FORMAT.getFormat());
+        new SimpleDateFormat(NeutronDateTimeFormat.FMT_LAST_RUN_DATE.getFormat());
     final Date now = new DateTime().minusHours(initialMode ? 876000 : hoursInPast).toDate();
 
     // Find the rocket's time file under the base directory:

--- a/src/main/java/gov/ca/cwds/neutron/launch/NeutronRocket.java
+++ b/src/main/java/gov/ca/cwds/neutron/launch/NeutronRocket.java
@@ -42,7 +42,8 @@ public class NeutronRocket implements InterruptableJob {
 
   private final StandardFlightSchedule flightSchedule;
 
-  private volatile FlightLog flightLog; // "volatile" shows changes immediately across threads
+  private volatile FlightLog flightLog = new FlightLog(); // "volatile" shows changes immediately
+                                                          // across threads
 
   /**
    * Constructor.

--- a/src/main/java/gov/ca/cwds/neutron/launch/NeutronRocket.java
+++ b/src/main/java/gov/ca/cwds/neutron/launch/NeutronRocket.java
@@ -66,6 +66,8 @@ public class NeutronRocket implements InterruptableJob {
   public void execute(JobExecutionContext context) throws JobExecutionException {
     final JobDataMap map = context.getJobDetail().getJobDataMap();
     final String rocketName = context.getTrigger().getJobKey().getName();
+    final String origThreadName = Thread.currentThread().getName();
+
     NeutronThreadUtils.nameThread(rocketName, this);
     LOGGER.info("\n\t>>>> LAUNCH! {}, instance # {}", rocket.getClass().getName(), instanceNumber);
 
@@ -92,12 +94,14 @@ public class NeutronRocket implements InterruptableJob {
       flightRecorder.summarizeFlight(flightSchedule, flightLog);
       LOGGER.info("FLIGHT SUMMARY: rocket: {}\n{}", rocketName, flightLog);
       MDC.remove("rocketLog"); // remove the logging context, no matter what happens
+      NeutronThreadUtils.nameThread(origThreadName, this);
     }
   }
 
   @Override
   public void interrupt() throws UnableToInterruptJobException {
     LOGGER.warn("ABORT FLIGHT! rocket: {}", this.getRocket().getClass());
+    getFlightLog().fail();
   }
 
   public FlightLog getFlightLog() {

--- a/src/main/java/gov/ca/cwds/neutron/rocket/BasePersonRocket.java
+++ b/src/main/java/gov/ca/cwds/neutron/rocket/BasePersonRocket.java
@@ -706,7 +706,7 @@ public abstract class BasePersonRocket<N extends PersistentObject, D extends Api
       // CHECKSTYLE:OFF
       if (LOGGER.isInfoEnabled()) {
         LOGGER.info("Updating last successful run time to {}",
-            new SimpleDateFormat(NeutronDateTimeFormat.LAST_RUN_DATE_FORMAT.getFormat())
+            new SimpleDateFormat(NeutronDateTimeFormat.FMT_LAST_RUN_DATE.getFormat())
                 .format(flightLog.getStartTime()));
       }
       // CHECKSTYLE:ON

--- a/src/main/java/gov/ca/cwds/neutron/rocket/ClientSQLResource.java
+++ b/src/main/java/gov/ca/cwds/neutron/rocket/ClientSQLResource.java
@@ -111,7 +111,6 @@ public class ClientSQLResource implements ApiMarker {
       + "    clt.IBMSNAP_OPERATION AS CLT_IBMSNAP_OPERATION \n"
       + KEY_SOURCE
       + "JOIN  CLIENT_T  clt ON clt.IDENTIFIER = gt.IDENTIFIER \n"
-   // + "WHERE clt.IBMSNAP_OPERATION IN ('I','U') \n" // SNAP-754
       + SEL_OPTIMIZE;
   //@formatter:on
 

--- a/src/main/java/gov/ca/cwds/neutron/rocket/LastFlightRocket.java
+++ b/src/main/java/gov/ca/cwds/neutron/rocket/LastFlightRocket.java
@@ -1,6 +1,6 @@
 package gov.ca.cwds.neutron.rocket;
 
-import static gov.ca.cwds.neutron.enums.NeutronDateTimeFormat.LAST_RUN_DATE_FORMAT;
+import static gov.ca.cwds.neutron.enums.NeutronDateTimeFormat.FMT_LAST_RUN_DATE;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -145,7 +145,7 @@ public abstract class LastFlightRocket implements Rocket, AtomShared, AtomRocket
     }
 
     try (BufferedReader br = new BufferedReader(new FileReader(lastRunTimeFilename))) { // NOSONAR
-      ret = new SimpleDateFormat(LAST_RUN_DATE_FORMAT.getFormat()).parse(br.readLine().trim()); // NOSONAR
+      ret = new SimpleDateFormat(FMT_LAST_RUN_DATE.getFormat()).parse(br.readLine().trim()); // NOSONAR
     } catch (IOException | ParseException e) {
       fail();
       throw CheeseRay.checked(LOGGER, e, "ERROR READING LAST RUN TIME: {}", e.getMessage());
@@ -164,13 +164,13 @@ public abstract class LastFlightRocket implements Rocket, AtomShared, AtomRocket
   public void writeLastSuccessfulRunTime(Date datetime) throws NeutronCheckedException {
     if (!isFailed()) {
       try (BufferedWriter w = new BufferedWriter(new FileWriter(lastRunTimeFilename))) { // NOSONAR
-        w.write(LAST_RUN_DATE_FORMAT.formatter().format(datetime));
+        w.write(FMT_LAST_RUN_DATE.formatter().format(datetime));
       } catch (IOException e) {
         fail();
         throw CheeseRay.checked(LOGGER, e, "ERROR WRITING TIMESTAMP FILE: {}", e.getMessage());
       }
     } else {
-      LOGGER.warn("Flight failed. Not writing last successful run timestamp");
+      LOGGER.warn("Flight failed. NOT writing last successful run timestamp!");
     }
   }
 
@@ -194,7 +194,7 @@ public abstract class LastFlightRocket implements Rocket, AtomShared, AtomRocket
    * Getter for last run time.
    * 
    * @return last time the rocket ran successfully, in format
-   *         {@link NeutronDateTimeFormat#LAST_RUN_DATE_FORMAT}
+   *         {@link NeutronDateTimeFormat#FMT_LAST_RUN_DATE}
    */
   public String getLastJobRunTimeFilename() {
     return lastRunTimeFilename;

--- a/src/main/java/gov/ca/cwds/neutron/util/shrinkray/NeutronDateUtils.java
+++ b/src/main/java/gov/ca/cwds/neutron/util/shrinkray/NeutronDateUtils.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.neutron.util.shrinkray;
 
-import static gov.ca.cwds.neutron.enums.NeutronDateTimeFormat.LEGACY_DATE_FORMAT;
-import static gov.ca.cwds.neutron.enums.NeutronDateTimeFormat.LEGACY_TIMESTAMP_FORMAT;
+import static gov.ca.cwds.neutron.enums.NeutronDateTimeFormat.FMT_LEGACY_DATE;
+import static gov.ca.cwds.neutron.enums.NeutronDateTimeFormat.FMT_LEGACY_TIMESTAMP;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -45,7 +45,7 @@ public class NeutronDateUtils {
     final String trimTimestamp = StringUtils.trim(timestamp);
     if (StringUtils.isNotEmpty(trimTimestamp)) {
       try {
-        return new SimpleDateFormat(LEGACY_TIMESTAMP_FORMAT.getFormat()).parse(trimTimestamp);
+        return new SimpleDateFormat(FMT_LEGACY_TIMESTAMP.getFormat()).parse(trimTimestamp);
       } catch (Exception e) {
         throw new NeutronRuntimeException(e);
       }
@@ -56,7 +56,7 @@ public class NeutronDateUtils {
   public static String makeTimestampString(final Date date) {
     final StringBuilder buf = new StringBuilder();
     buf.append("TIMESTAMP('")
-        .append(new SimpleDateFormat(LEGACY_TIMESTAMP_FORMAT.getFormat()).format(date))
+        .append(new SimpleDateFormat(FMT_LEGACY_TIMESTAMP.getFormat()).format(date))
         .append("')");
     return buf.toString();
   }
@@ -70,16 +70,16 @@ public class NeutronDateUtils {
       useThisDate = cal.getTime();
     }
 
-    return new SimpleDateFormat(LEGACY_TIMESTAMP_FORMAT.getFormat()).format(useThisDate);
+    return new SimpleDateFormat(FMT_LEGACY_TIMESTAMP.getFormat()).format(useThisDate);
   }
 
   public static String makeSimpleDateString(final Date date) {
-    return new SimpleDateFormat(LEGACY_DATE_FORMAT.getFormat()).format(date);
+    return new SimpleDateFormat(FMT_LEGACY_DATE.getFormat()).format(date);
   }
 
   public static String makeTimestampStringLookBack(final Date date) {
     String ret;
-    final DateFormat fmt = new SimpleDateFormat(LEGACY_TIMESTAMP_FORMAT.getFormat());
+    final DateFormat fmt = new SimpleDateFormat(FMT_LEGACY_TIMESTAMP.getFormat());
 
     if (date != null) {
       ret = fmt.format(lookBack(date));

--- a/src/test/java/gov/ca/cwds/jobs/RelationshipIndexerJobTest.java
+++ b/src/test/java/gov/ca/cwds/jobs/RelationshipIndexerJobTest.java
@@ -36,7 +36,7 @@ public class RelationshipIndexerJobTest extends Goddard<ReplicatedRelationships,
     target =
         new RelationshipIndexerJob(dao, esDao, lastRunFile, MAPPER, flightPlan, launchDirector);
     target.writeLastSuccessfulRunTime(
-        new SimpleDateFormat(NeutronDateTimeFormat.LAST_RUN_DATE_FORMAT.getFormat())
+        new SimpleDateFormat(NeutronDateTimeFormat.FMT_LAST_RUN_DATE.getFormat())
             .parse("2018-01-22 10:53:20"));
   }
 

--- a/src/test/java/gov/ca/cwds/jobs/schedule/NeutronRocketTest.java
+++ b/src/test/java/gov/ca/cwds/jobs/schedule/NeutronRocketTest.java
@@ -1,6 +1,5 @@
 package gov.ca.cwds.jobs.schedule;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -38,8 +37,7 @@ public class NeutronRocketTest extends Goddard {
     super.setup();
 
     dao = new TestNormalizedEntityDao(sessionFactory);
-    rocket = new TestIndexerJob(dao, esDao, lastRunFile, MAPPER, sessionFactory,
-        flightRecorder);
+    rocket = new TestIndexerJob(dao, esDao, lastRunFile, MAPPER, sessionFactory, flightRecorder);
     rocket.setFlightPlan(flightPlan);
     rocket.init(this.tempFile.getAbsolutePath(), flightPlan);
 
@@ -104,8 +102,11 @@ public class NeutronRocketTest extends Goddard {
   @Test
   public void getTrack_Args__() throws Exception {
     FlightLog actual = target.getFlightLog();
-    FlightLog expected = null;
-    assertThat(actual, is(equalTo(expected)));
+    FlightLog expected = new FlightLog();
+    expected.setStartTime(actual.getStartTime()); // Manual
+
+    // assertThat(actual, is(equalTo(expected)));
+    assertThat(actual, is(notNullValue()));
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/neutron/rocket/BasePersonRocketTest.java
+++ b/src/test/java/gov/ca/cwds/neutron/rocket/BasePersonRocketTest.java
@@ -691,8 +691,7 @@ public class BasePersonRocketTest extends Goddard<TestNormalizedEntity, TestDeno
 
   @Test
   public void prepHibernatePull_Args__Session__Transaction__Date() throws Exception {
-    target.runInsertAllLastChangeKeys(session, lastRunTime,
-        ClientSQLResource.INS_CLI_LST_CHG);
+    target.runInsertAllLastChangeKeys(session, lastRunTime, ClientSQLResource.INS_CLI_LST_CHG);
   }
 
   @Test
@@ -945,7 +944,8 @@ public class BasePersonRocketTest extends Goddard<TestNormalizedEntity, TestDeno
     final String actual =
         ((UpdateRequest) request).upsertRequest().toString().replaceAll("\\s+", "");
     final String expected =
-        "index{[null][person][abc1234567],source[{\"sensitivity_indicator\":\"N\",\"source\":\"\",\"legacy_descriptor\":{},\"legacy_source_table\":\"CRAP_T\",\"legacy_id\":\"abc1234567\",\"addresses\":[],\"phone_numbers\":[],\"languages\":[],\"csec\":[],\"id\":\"abc1234567\"}]}";
+        "index{[null][person][abc1234567],source[{\"first_name\":null,\"middle_name\":null,\"last_name\":null,\"name_suffix\":null,\"date_of_birth\":null,\"ssn\":null,\"sensitivity_indicator\":\"N\",\"source\":\"\",\"legacy_descriptor\":{},\"legacy_source_table\":\"CRAP_T\",\"legacy_id\":\"abc1234567\",\"addresses\":[],\"phone_numbers\":[],\"languages\":[],\"csec\":[],\"id\":\"abc1234567\"}]}";
+
     assertThat(actual, is(equalTo(expected)));
   }
 
@@ -959,7 +959,7 @@ public class BasePersonRocketTest extends Goddard<TestNormalizedEntity, TestDeno
 
     final String actual = request.upsertRequest().toString().replaceAll("\\s+", "");
     final String expected =
-        "index{[null][person][abc1234567],source[{\"sensitivity_indicator\":\"N\",\"source\":\"\",\"legacy_descriptor\":{},\"legacy_source_table\":\"CRAP_T\",\"legacy_id\":\"abc1234567\",\"addresses\":[],\"phone_numbers\":[],\"languages\":[],\"csec\":[],\"id\":\"abc1234567\"}]}";
+        "index{[null][person][abc1234567],source[{\"first_name\":null,\"middle_name\":null,\"last_name\":null,\"name_suffix\":null,\"date_of_birth\":null,\"ssn\":null,\"sensitivity_indicator\":\"N\",\"source\":\"\",\"legacy_descriptor\":{},\"legacy_source_table\":\"CRAP_T\",\"legacy_id\":\"abc1234567\",\"addresses\":[],\"phone_numbers\":[],\"languages\":[],\"csec\":[],\"id\":\"abc1234567\"}]}";
     assertThat(actual, is(equalTo(expected)));
   }
 

--- a/src/test/java/gov/ca/cwds/neutron/rocket/LastFlightRocketTest.java
+++ b/src/test/java/gov/ca/cwds/neutron/rocket/LastFlightRocketTest.java
@@ -105,7 +105,7 @@ public class LastFlightRocketTest extends Goddard<TestNormalizedEntity, TestDeno
   public void determineLastSuccessfulRunTime_Args__() throws Exception {
     final Date actual = target.determineLastSuccessfulRunTime();
     final Date expected =
-        NeutronDateTimeFormat.LAST_RUN_DATE_FORMAT.formatter().parse(FIXED_DATETIME);
+        NeutronDateTimeFormat.FMT_LAST_RUN_DATE.formatter().parse(FIXED_DATETIME);
     assertThat(actual, is(equalTo(expected)));
   }
 
@@ -114,7 +114,7 @@ public class LastFlightRocketTest extends Goddard<TestNormalizedEntity, TestDeno
     target.setLastRunTimeFilename("zugzug_oompa_loompa");
     final Date actual = target.determineLastSuccessfulRunTime();
     final Date expected =
-        NeutronDateTimeFormat.LAST_RUN_DATE_FORMAT.formatter().parse(FIXED_DATETIME);
+        NeutronDateTimeFormat.FMT_LAST_RUN_DATE.formatter().parse(FIXED_DATETIME);
     assertThat(actual, is(equalTo(expected)));
   }
 


### PR DESCRIPTION
Top-level client fields, like birth date, are not removed from Elasticsearch documents, because class ElasticSearchPerson did not stream JSON for null fields.

Corrected in api-core for name fields, SSN, and birth date using Jackson's "JsonInclude" annotation:

```
@JsonProperty("date_of_birth")
@JsonInclude(JsonInclude.Include.ALWAYS)
private String dateOfBirth;
```