### PR TITLE
AR-338: add total_milliseconds metric

### DIFF
--- a/src/main/java/gov/ca/cwds/neutron/flight/FlightLog.java
+++ b/src/main/java/gov/ca/cwds/neutron/flight/FlightLog.java
@@ -846,6 +846,9 @@ public class FlightLog implements ApiMarker, AtomRocketControl {
       LOGGER.debug("total seconds: {}", totalSeconds);
       attribs.putIfAbsent("total_seconds", totalSeconds);
 
+      final long totalMilliSeconds = endTime - startTime;
+      attribs.putIfAbsent("total_milliseconds", totalMilliSeconds);
+
       if (!attribs.isEmpty()) {
         try {
           LOGGER.info("****** Notify New Relic ****** event: {}, attribs: {}", eventType,


### PR DESCRIPTION
This adds a total_milliseconds metric, since the (rounded) total_seconds metric is limited in accuracy and doesn't match the DB2 replication latency metric units.

See https://osi-cwds.atlassian.net/browse/AR-338 for context